### PR TITLE
Add diffuse.yaml config and Docker Hub CI

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,23 +5,23 @@ on:
     tags: ["v*"]
 
 env:
-  IMAGE_NAME: diffuseproject/${{ github.event.repository.name }}
+  IMAGE_NAME: diffuseproject/waterflow
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,32 @@
+name: Build and push Docker image
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  IMAGE_NAME: diffuseproject/${{ github.event.repository.name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}:latest
+          secrets: |
+            hf_token=${{ secrets.HF_TOKEN }}

--- a/diffuse.yaml
+++ b/diffuse.yaml
@@ -1,7 +1,7 @@
 # diffuse.yaml -- the contract between WaterFlow and Diffuse.
 #
 # Apply with: diffuse apply
-# Run with:   diffuse run start --profile waterflow-train-gvp
+# Run with:   diffuse run trigger --profile waterflow-train-gvp
 #
 # Idempotent -- safe to apply repeatedly.
 
@@ -17,13 +17,12 @@ description: >
 profiles:
   - slug: waterflow-train-gvp
     name: WaterFlow Train (GVP)
-    description: Train flow matching model with GVP encoder
     container:
       image: diffuseproject/waterflow
       tag: latest
       gpus:
         min: 1
-    entrypoint: train
+    entrypoint: null
     input_schema:
       inputs:
         - key: encoder_type
@@ -32,14 +31,29 @@ profiles:
           allowed_values: [gvp]
           default: gvp
         - key: epochs
-          type: int
+          type: number
           default: "200"
         - key: batch_size
-          type: int
+          type: number
           default: "4"
         - key: lr
           type: number
           default: "1e-4"
+        - key: scheduler
+          type: text
+          default: cosine
+        - key: warmup_steps
+          type: number
+          default: "500"
+        - key: save_dir
+          type: text
+          default: /data/checkpoints
+        - key: num_workers
+          type: number
+          default: "4"
+        - key: use_self_cond
+          type: boolean
+          default: true
         - key: run_name
           type: text
         - key: train_list
@@ -48,16 +62,48 @@ profiles:
         - key: val_list
           type: text
           default: /data/splits/valid_list_0.05.txt
+    run_config_defaults:
+      shared_memory_size: "16Gi"
+      runtime_class: nvidia
+      image_pull_policy: IfNotPresent
+      env:
+        WANDB_MODE: disabled
+        NVIDIA_VISIBLE_DEVICES: all
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      volumes:
+        - name: waterflow-data
+          hostPath: /data/waterflow
+          mountPath: /data
+        - name: pdb-data
+          hostPath: /mnt/diffuse-public/pdb_redo_data
+          mountPath: /data/pdb
+          readOnly: true
+      args_template:
+        base_command: [train]
+        flag_args:
+          encoder_type: --encoder_type
+          epochs: --epochs
+          batch_size: --batch_size
+          lr: --lr
+          train_list: --train_list
+          val_list: --val_list
+          scheduler: --scheduler
+          warmup_steps: --warmup_steps
+          save_dir: --save_dir
+          run_name: --run_name
+          num_workers: --num_workers
+        boolean_args:
+          use_self_cond: --use_self_cond
+        static_args: [--base_pdb_dir, /data/pdb]
 
   - slug: waterflow-train-esm
     name: WaterFlow Train (ESM)
-    description: Train flow matching model with ESM encoder
     container:
       image: diffuseproject/waterflow
       tag: latest
       gpus:
         min: 1
-    entrypoint: train
+    entrypoint: null
     input_schema:
       inputs:
         - key: encoder_type
@@ -66,14 +112,29 @@ profiles:
           allowed_values: [esm]
           default: esm
         - key: epochs
-          type: int
+          type: number
           default: "200"
         - key: batch_size
-          type: int
+          type: number
           default: "4"
         - key: lr
           type: number
           default: "1e-4"
+        - key: scheduler
+          type: text
+          default: cosine
+        - key: warmup_steps
+          type: number
+          default: "500"
+        - key: save_dir
+          type: text
+          default: /data/checkpoints
+        - key: num_workers
+          type: number
+          default: "4"
+        - key: use_self_cond
+          type: boolean
+          default: true
         - key: run_name
           type: text
         - key: train_list
@@ -82,16 +143,48 @@ profiles:
         - key: val_list
           type: text
           default: /data/splits/valid_list_0.05.txt
+    run_config_defaults:
+      shared_memory_size: "16Gi"
+      runtime_class: nvidia
+      image_pull_policy: IfNotPresent
+      env:
+        WANDB_MODE: disabled
+        NVIDIA_VISIBLE_DEVICES: all
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      volumes:
+        - name: waterflow-data
+          hostPath: /data/waterflow
+          mountPath: /data
+        - name: pdb-data
+          hostPath: /mnt/diffuse-public/pdb_redo_data
+          mountPath: /data/pdb
+          readOnly: true
+      args_template:
+        base_command: [train]
+        flag_args:
+          encoder_type: --encoder_type
+          epochs: --epochs
+          batch_size: --batch_size
+          lr: --lr
+          train_list: --train_list
+          val_list: --val_list
+          scheduler: --scheduler
+          warmup_steps: --warmup_steps
+          save_dir: --save_dir
+          run_name: --run_name
+          num_workers: --num_workers
+        boolean_args:
+          use_self_cond: --use_self_cond
+        static_args: [--base_pdb_dir, /data/pdb]
 
   - slug: waterflow-train-slae
     name: WaterFlow Train (SLAE)
-    description: Train flow matching model with SLAE encoder
     container:
       image: diffuseproject/waterflow
       tag: latest
       gpus:
         min: 1
-    entrypoint: train
+    entrypoint: null
     input_schema:
       inputs:
         - key: encoder_type
@@ -100,14 +193,29 @@ profiles:
           allowed_values: [slae]
           default: slae
         - key: epochs
-          type: int
+          type: number
           default: "200"
         - key: batch_size
-          type: int
+          type: number
           default: "4"
         - key: lr
           type: number
           default: "1e-4"
+        - key: scheduler
+          type: text
+          default: cosine
+        - key: warmup_steps
+          type: number
+          default: "500"
+        - key: save_dir
+          type: text
+          default: /data/checkpoints
+        - key: num_workers
+          type: number
+          default: "4"
+        - key: use_self_cond
+          type: boolean
+          default: true
         - key: run_name
           type: text
         - key: train_list
@@ -116,42 +224,127 @@ profiles:
         - key: val_list
           type: text
           default: /data/splits/valid_list_0.05.txt
+    run_config_defaults:
+      shared_memory_size: "16Gi"
+      runtime_class: nvidia
+      image_pull_policy: IfNotPresent
+      env:
+        WANDB_MODE: disabled
+        NVIDIA_VISIBLE_DEVICES: all
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      volumes:
+        - name: waterflow-data
+          hostPath: /data/waterflow
+          mountPath: /data
+        - name: pdb-data
+          hostPath: /mnt/diffuse-public/pdb_redo_data
+          mountPath: /data/pdb
+          readOnly: true
+      args_template:
+        base_command: [train]
+        flag_args:
+          encoder_type: --encoder_type
+          epochs: --epochs
+          batch_size: --batch_size
+          lr: --lr
+          train_list: --train_list
+          val_list: --val_list
+          scheduler: --scheduler
+          warmup_steps: --warmup_steps
+          save_dir: --save_dir
+          run_name: --run_name
+          num_workers: --num_workers
+        boolean_args:
+          use_self_cond: --use_self_cond
+        static_args: [--base_pdb_dir, /data/pdb]
 
   - slug: waterflow-inference
     name: WaterFlow Inference
-    description: Run inference with a trained WaterFlow checkpoint
     container:
       image: diffuseproject/waterflow
       tag: latest
       gpus:
         min: 1
-    entrypoint: inference
+    entrypoint: null
     input_schema:
       inputs:
         - key: run_dir
           type: text
           required: true
         - key: num_steps
-          type: int
+          type: number
           default: "100"
         - key: pdb_list
           type: text
           default: /data/splits/valid_list_0.05.txt
+        - key: method
+          type: text
+          default: rk4
+        - key: use_sc
+          type: boolean
+          default: true
+    run_config_defaults:
+      shared_memory_size: "16Gi"
+      runtime_class: nvidia
+      image_pull_policy: IfNotPresent
+      env:
+        WANDB_MODE: disabled
+        NVIDIA_VISIBLE_DEVICES: all
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      volumes:
+        - name: waterflow-data
+          hostPath: /data/waterflow
+          mountPath: /data
+        - name: pdb-data
+          hostPath: /mnt/diffuse-public/pdb_redo_data
+          mountPath: /data/pdb
+          readOnly: true
+      args_template:
+        base_command: [inference]
+        flag_args:
+          run_dir: --run_dir
+          pdb_list: --pdb_list
+          method: --method
+          num_steps: --num_steps
+        boolean_args:
+          use_sc: --use_sc
+        static_args: [--output_dir, /data/outputs, --base_pdb_dir, /data/pdb]
 
   - slug: waterflow-generate-esm
     name: WaterFlow Generate ESM Embeddings
-    description: Generate ESM3 embeddings for PDB files
     container:
       image: diffuseproject/waterflow
       tag: latest
       gpus:
         min: 1
-    entrypoint: generate-esm
+    entrypoint: null
     input_schema:
       inputs:
         - key: split_file
           type: text
           default: /data/splits/train_list_0.95.txt
+    run_config_defaults:
+      shared_memory_size: "16Gi"
+      runtime_class: nvidia
+      image_pull_policy: IfNotPresent
+      env:
+        WANDB_MODE: disabled
+        NVIDIA_VISIBLE_DEVICES: all
+        NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      volumes:
+        - name: waterflow-data
+          hostPath: /data/waterflow
+          mountPath: /data
+        - name: pdb-data
+          hostPath: /mnt/diffuse-public/pdb_redo_data
+          mountPath: /data/pdb
+          readOnly: true
+      args_template:
+        base_command: [generate-esm]
+        flag_args:
+          split_file: --split_file
+        boolean_args: {}
+        static_args: [--cache_dir, /data/cache, --base_pdb_dir, /data/pdb]
 
 fields:
   - key: waterflow_encoder_type

--- a/diffuse.yaml
+++ b/diffuse.yaml
@@ -1,0 +1,173 @@
+# diffuse.yaml -- the contract between WaterFlow and Diffuse.
+#
+# Apply with: diffuse apply
+# Run with:   diffuse run start --profile waterflow-train-gvp
+#
+# Idempotent -- safe to apply repeatedly.
+
+version: 1
+
+type: waterflow
+name: WaterFlow
+description: >
+  Protein water structure prediction via flow matching.
+  Predicts water molecule positions around proteins using
+  continuous normalizing flows with GVP, ESM, or SLAE encoders.
+
+profiles:
+  - slug: waterflow-train-gvp
+    name: WaterFlow Train (GVP)
+    description: Train flow matching model with GVP encoder
+    container:
+      image: diffuseproject/waterflow
+      tag: latest
+      gpus:
+        min: 1
+    entrypoint: train
+    input_schema:
+      inputs:
+        - key: encoder_type
+          type: enum
+          required: true
+          allowed_values: [gvp]
+          default: gvp
+        - key: epochs
+          type: int
+          default: "200"
+        - key: batch_size
+          type: int
+          default: "4"
+        - key: lr
+          type: number
+          default: "1e-4"
+        - key: run_name
+          type: text
+        - key: train_list
+          type: text
+          default: /data/splits/train_list_0.95.txt
+        - key: val_list
+          type: text
+          default: /data/splits/valid_list_0.05.txt
+
+  - slug: waterflow-train-esm
+    name: WaterFlow Train (ESM)
+    description: Train flow matching model with ESM encoder
+    container:
+      image: diffuseproject/waterflow
+      tag: latest
+      gpus:
+        min: 1
+    entrypoint: train
+    input_schema:
+      inputs:
+        - key: encoder_type
+          type: enum
+          required: true
+          allowed_values: [esm]
+          default: esm
+        - key: epochs
+          type: int
+          default: "200"
+        - key: batch_size
+          type: int
+          default: "4"
+        - key: lr
+          type: number
+          default: "1e-4"
+        - key: run_name
+          type: text
+        - key: train_list
+          type: text
+          default: /data/splits/train_list_0.95.txt
+        - key: val_list
+          type: text
+          default: /data/splits/valid_list_0.05.txt
+
+  - slug: waterflow-train-slae
+    name: WaterFlow Train (SLAE)
+    description: Train flow matching model with SLAE encoder
+    container:
+      image: diffuseproject/waterflow
+      tag: latest
+      gpus:
+        min: 1
+    entrypoint: train
+    input_schema:
+      inputs:
+        - key: encoder_type
+          type: enum
+          required: true
+          allowed_values: [slae]
+          default: slae
+        - key: epochs
+          type: int
+          default: "200"
+        - key: batch_size
+          type: int
+          default: "4"
+        - key: lr
+          type: number
+          default: "1e-4"
+        - key: run_name
+          type: text
+        - key: train_list
+          type: text
+          default: /data/splits/train_list_0.95.txt
+        - key: val_list
+          type: text
+          default: /data/splits/valid_list_0.05.txt
+
+  - slug: waterflow-inference
+    name: WaterFlow Inference
+    description: Run inference with a trained WaterFlow checkpoint
+    container:
+      image: diffuseproject/waterflow
+      tag: latest
+      gpus:
+        min: 1
+    entrypoint: inference
+    input_schema:
+      inputs:
+        - key: run_dir
+          type: text
+          required: true
+        - key: num_steps
+          type: int
+          default: "100"
+        - key: pdb_list
+          type: text
+          default: /data/splits/valid_list_0.05.txt
+
+  - slug: waterflow-generate-esm
+    name: WaterFlow Generate ESM Embeddings
+    description: Generate ESM3 embeddings for PDB files
+    container:
+      image: diffuseproject/waterflow
+      tag: latest
+      gpus:
+        min: 1
+    entrypoint: generate-esm
+    input_schema:
+      inputs:
+        - key: split_file
+          type: text
+          default: /data/splits/train_list_0.95.txt
+
+fields:
+  - key: waterflow_encoder_type
+    type: enum
+    display_name: Encoder Type
+    allowed_values: [gvp, esm, slae]
+    required: true
+  - key: waterflow_epochs
+    type: number
+    display_name: Epochs
+    default: "200"
+  - key: waterflow_batch_size
+    type: number
+    display_name: Batch Size
+    default: "4"
+  - key: waterflow_learning_rate
+    type: number
+    display_name: Learning Rate
+    default: "1e-4"

--- a/diffuse.yaml
+++ b/diffuse.yaml
@@ -32,25 +32,25 @@ profiles:
           default: gvp
         - key: epochs
           type: number
-          default: "200"
+          default: 200
         - key: batch_size
           type: number
-          default: "4"
+          default: 4
         - key: lr
           type: number
-          default: "1e-4"
+          default: 1e-3
         - key: scheduler
           type: text
           default: cosine
         - key: warmup_steps
           type: number
-          default: "500"
+          default: 500
         - key: save_dir
           type: text
           default: /data/checkpoints
         - key: num_workers
           type: number
-          default: "4"
+          default: 4
         - key: use_self_cond
           type: boolean
           default: true
@@ -113,25 +113,25 @@ profiles:
           default: esm
         - key: epochs
           type: number
-          default: "200"
+          default: 200
         - key: batch_size
           type: number
-          default: "4"
+          default: 4
         - key: lr
           type: number
-          default: "1e-4"
+          default: 1e-3
         - key: scheduler
           type: text
           default: cosine
         - key: warmup_steps
           type: number
-          default: "500"
+          default: 500
         - key: save_dir
           type: text
           default: /data/checkpoints
         - key: num_workers
           type: number
-          default: "4"
+          default: 4
         - key: use_self_cond
           type: boolean
           default: true
@@ -194,25 +194,25 @@ profiles:
           default: slae
         - key: epochs
           type: number
-          default: "200"
+          default: 200
         - key: batch_size
           type: number
-          default: "4"
+          default: 4
         - key: lr
           type: number
-          default: "1e-4"
+          default: 1e-3
         - key: scheduler
           type: text
           default: cosine
         - key: warmup_steps
           type: number
-          default: "500"
+          default: 500
         - key: save_dir
           type: text
           default: /data/checkpoints
         - key: num_workers
           type: number
-          default: "4"
+          default: 4
         - key: use_self_cond
           type: boolean
           default: true
@@ -273,7 +273,7 @@ profiles:
           required: true
         - key: num_steps
           type: number
-          default: "100"
+          default: 100
         - key: pdb_list
           type: text
           default: /data/splits/valid_list_0.05.txt
@@ -355,12 +355,12 @@ fields:
   - key: waterflow_epochs
     type: number
     display_name: Epochs
-    default: "200"
+    default: 200
   - key: waterflow_batch_size
     type: number
     display_name: Batch Size
-    default: "4"
+    default: 4
   - key: waterflow_learning_rate
     type: number
     display_name: Learning Rate
-    default: "1e-4"
+    default: 1e-3


### PR DESCRIPTION
## Summary

- Adds `diffuse.yaml` declarative config with 5 profiles for the generic runner system
- Each profile includes `run_config_defaults` with `args_template` so the generic runner builds the same CLI args the hardcoded WaterFlow flow produces — no container changes needed
- Adds GitHub Actions workflow to build and push `diffuseproject/waterflow` to Docker Hub on version tags
- Full `input_schema` with all parameters and defaults for each preset

Profiles: `waterflow-train-gvp`, `waterflow-train-esm`, `waterflow-train-slae`, `waterflow-inference`, `waterflow-generate-esm`

Companion PR: diff-use/webapp#203 (generic experiment runner)

## Test plan

- [ ] Verify `diffuse.yaml` loads via `diffuse apply` against webapp
- [ ] Tag a test version to verify Docker Hub build workflow
- [ ] Trigger a run via `POST /api/runs` with `profile_slug=waterflow-train-gvp` and verify container gets correct CLI args
- [ ] Confirm existing hardcoded `run-waterflow-k8s` flow still works unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WaterFlow contract with training profiles for GVP, ESM, and SLAE encoders, plus inference and embedding-generation profiles.
  * Exposed top-level configurable parameters: encoder type, epochs, batch size, learning rate, and run identifiers; profiles include GPU/runtime defaults, env settings, mounts, and CLI argument mappings.

* **Chores**
  * Added an automated workflow to build and publish Docker images on versioned releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->