### PR TITLE
Fix LR defaults: use 0.001 for proper YAML numeric parsing

### DIFF
--- a/diffuse.yaml
+++ b/diffuse.yaml
@@ -38,7 +38,7 @@ profiles:
           default: 4
         - key: lr
           type: number
-          default: 1e-3
+          default: 0.001
         - key: scheduler
           type: text
           default: cosine
@@ -119,7 +119,7 @@ profiles:
           default: 4
         - key: lr
           type: number
-          default: 1e-3
+          default: 0.001
         - key: scheduler
           type: text
           default: cosine
@@ -200,7 +200,7 @@ profiles:
           default: 4
         - key: lr
           type: number
-          default: 1e-3
+          default: 0.001
         - key: scheduler
           type: text
           default: cosine
@@ -363,4 +363,4 @@ fields:
   - key: waterflow_learning_rate
     type: number
     display_name: Learning Rate
-    default: 1e-3
+    default: 0.001


### PR DESCRIPTION
## Summary
- PyYAML parses `1e-3` (no decimal point) as a **string**, not a float
- Changed all `default: 1e-3` to `default: 0.001` so schema validation sees a proper numeric type
- Caught during post-merge validation of #79

## Test plan
- [x] Verified with PyYAML `safe_load` that all numeric defaults now parse as `int` or `float`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default learning rate configuration values for model training operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->