### PR TITLE
Add Astera ACTL overlay image

### DIFF
--- a/.actlignore
+++ b/.actlignore
@@ -1,0 +1,15 @@
+# Keep large experiment data on /mnt/diffuse-shared/waterflow (also exposed as
+# /data inside the ACTL image), not in the synced source checkout.
+data/
+flow_cache/
+wandb/
+logs/
+outputs/
+checkpoints/
+*.ckpt
+*.h5
+*.hdf5
+*.pt
+*.pth
+*.safetensors
+*.wandb

--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -1,0 +1,66 @@
+name: Astera ACTL Docker image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.astera
+      - .github/workflows/astera-docker.yml
+  workflow_dispatch:
+
+env:
+  ASTERA_REGISTRY: harbor.astera.sh
+  ASTERA_IMAGE_NAME: library/waterflow
+  ACTL_VERSION_TAG: main-actl-2026-06-08
+  WATERFLOW_BASE_IMAGE: ${{ vars.WATERFLOW_BASE_IMAGE || 'docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc' }}
+
+jobs:
+  astera:
+    name: Build Astera ACTL image
+    runs-on: astera-sh-builder
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Harbor
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.ASTERA_REGISTRY }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.ACTL_VERSION_TAG }}
+            type=raw,value=main-actl
+            type=raw,value=actl
+            type=sha,prefix=sha-
+
+      - name: Build and push Astera image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.astera
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            WATERFLOW_BASE_IMAGE=${{ env.WATERFLOW_BASE_IMAGE }}
+          cache-from: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max
+          provenance: false
+
+      - name: Image digest
+        run: echo "Astera WaterFlow image pushed with digest ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -11,7 +11,7 @@ on:
 env:
   ASTERA_REGISTRY: harbor.astera.sh
   ASTERA_IMAGE_NAME: library/waterflow
-  ACTL_VERSION_TAG: main-actl-2026-06-08
+  ACTL_VERSION_TAG: main-actl-2026-06-09
   WATERFLOW_BASE_IMAGE: ${{ vars.WATERFLOW_BASE_IMAGE || 'docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc' }}
 
 jobs:

--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -9,7 +9,12 @@ on:
   workflow_dispatch:
 
 env:
-  ASTERA_REGISTRY: harbor.astera.sh
+  # Only the registry HOST is secret (repo secret ASTERA_REGISTRY); the image
+  # path and tag stay plain env. This repo is public, so its Actions logs are
+  # public and only secrets get masked. Masking is substring-based, so keeping
+  # the secret to the bare host masks it inside every longer image ref while
+  # leaving tags and digests readable when a build fails. It is set per job
+  # because workflow-level env cannot read the secrets context.
   ASTERA_IMAGE_NAME: library/waterflow
   ACTL_VERSION_TAG: main-actl-2026-06-09
   WATERFLOW_BASE_IMAGE: ${{ vars.WATERFLOW_BASE_IMAGE || 'docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc' }}
@@ -20,8 +25,25 @@ jobs:
     runs-on: astera-sh-builder
     permissions:
       contents: read
+    env:
+      ASTERA_REGISTRY: ${{ secrets.ASTERA_REGISTRY }}
 
     steps:
+      - name: Verify registry configuration
+        run: |
+          # No in-repo fallback, so an unset secret must fail here rather than
+          # later: docker/login-action treats an empty registry as Docker Hub
+          # and would send HARBOR_USERNAME/HARBOR_PASSWORD to a third party.
+          if [ -z "${ASTERA_REGISTRY}" ]; then
+            echo "ASTERA_REGISTRY repository secret must be set."
+            exit 1
+          fi
+          case "${ASTERA_REGISTRY}" in
+            docker.io|index.docker.io|registry-1.docker.io)
+              echo "ASTERA_REGISTRY must be the internal registry, not a public one."
+              exit 1 ;;
+          esac
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -10,7 +10,7 @@
 #   docker buildx build --platform linux/amd64 \
 #     -f Dockerfile.astera \
 #     --build-arg WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc \
-#     -t harbor.astera.sh/library/waterflow:main-actl-2026-06-08 \
+#     -t harbor.astera.sh/library/waterflow:main-actl-2026-06-09 \
 #     .
 
 ARG WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc
@@ -18,7 +18,7 @@ FROM ${WATERFLOW_BASE_IMAGE} AS astera
 
 USER root
 
-ARG ACTL_PACKAGES="bash ca-certificates rsync tini vim nano emacs-nox git zsh"
+ARG ACTL_PACKAGES="bash ca-certificates curl wget rsync tini vim nano emacs-nox git zsh htop tmux ncdu iputils-ping dnsutils"
 
 ENV DEBIAN_FRONTEND=noninteractive \
     HOME=/home/dev \
@@ -122,7 +122,10 @@ EOF
 RUN chmod 0644 /usr/local/share/actl-waterflow-shell-init.sh \
     && printf '\n# Astera WaterFlow environment\n[ -r /usr/local/share/actl-waterflow-shell-init.sh ] && . /usr/local/share/actl-waterflow-shell-init.sh\n' >> /etc/bash.bashrc \
     && printf '\n# Astera WaterFlow environment\n[ -r /usr/local/share/actl-waterflow-shell-init.sh ] && . /usr/local/share/actl-waterflow-shell-init.sh\n' >> /etc/zsh/zshrc \
-    && for cmd in waterflow python rsync tini vim nano emacs zsh; do command -v "${cmd}" >/dev/null; done
+    && for cmd in \
+        waterflow python curl wget rsync tini vim nano emacs git zsh htop tmux ncdu ping dig; do \
+          command -v "${cmd}" >/dev/null; \
+        done
 
 WORKDIR /home/dev
 ENTRYPOINT []

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -1,0 +1,129 @@
+# syntax=docker/dockerfile:1
+# WaterFlow - Astera ACTL overlay.
+#
+# The public diffuseproject/waterflow image bakes the scientific stack and the
+# gated ESM3 model. This overlay keeps that stack intact and only adds ACTL
+# workspace conventions: /home/dev as the persisted home, editor/sync tooling,
+# a shell-friendly command, and shared-volume data defaults.
+#
+# Build locally:
+#   docker buildx build --platform linux/amd64 \
+#     -f Dockerfile.astera \
+#     --build-arg WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc \
+#     -t harbor.astera.sh/library/waterflow:main-actl-2026-06-08 \
+#     .
+
+ARG WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc
+FROM ${WATERFLOW_BASE_IMAGE} AS astera
+
+USER root
+
+ARG ACTL_PACKAGES="bash ca-certificates rsync tini vim nano emacs-nox git zsh"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/home/dev \
+    XDG_CONFIG_HOME=/home/dev/.config \
+    XDG_CACHE_HOME=/home/dev/.cache \
+    XDG_DATA_HOME=/home/dev/.local/share \
+    SHELL=/bin/bash \
+    VIRTUAL_ENV=/app/.venv \
+    PYTHONPATH=/home/dev/workspace:/app \
+    PATH="/app/.venv/bin:${PATH}" \
+    WATERFLOW_DATA_DIR=/mnt/diffuse-shared/waterflow \
+    WATERFLOW_PDB_DIR=/data/pdb \
+    WATERFLOW_CACHE_DIR=/data/cache \
+    WATERFLOW_CHECKPOINT_DIR=/data/checkpoints \
+    WATERFLOW_OUTPUT_DIR=/data/outputs \
+    WATERFLOW_LOG_DIR=/data/logs \
+    WATERFLOW_SPLITS_DIR=/data/splits
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ${ACTL_PACKAGES} \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && mkdir -p \
+        /home/dev/.config \
+        /home/dev/.cache \
+        /home/dev/.local/share \
+        /home/dev/workspace \
+        /mnt/diffuse-shared/waterflow/pdb \
+        /mnt/diffuse-shared/waterflow/cache \
+        /mnt/diffuse-shared/waterflow/checkpoints \
+        /mnt/diffuse-shared/waterflow/outputs \
+        /mnt/diffuse-shared/waterflow/logs \
+        /mnt/diffuse-shared/waterflow/splits \
+        /etc/zsh \
+    && rm -rf /data \
+    && ln -s /mnt/diffuse-shared/waterflow /data \
+    && cat > /usr/local/bin/waterflow <<'EOF'
+#!/usr/bin/env bash
+if [ -d /mnt/diffuse-shared ]; then
+  mkdir -p \
+    /mnt/diffuse-shared/waterflow/pdb \
+    /mnt/diffuse-shared/waterflow/cache \
+    /mnt/diffuse-shared/waterflow/checkpoints \
+    /mnt/diffuse-shared/waterflow/outputs \
+    /mnt/diffuse-shared/waterflow/logs \
+    /mnt/diffuse-shared/waterflow/splits 2>/dev/null || true
+fi
+entrypoint=/app/entrypoint.sh
+if [ -x /home/dev/workspace/docker/entrypoint.sh ] && [ -d /home/dev/workspace/scripts ]; then
+  export WATERFLOW_APP_DIR=/home/dev/workspace
+  entrypoint=/home/dev/workspace/docker/entrypoint.sh
+fi
+exec "${entrypoint}" "$@"
+EOF
+RUN chmod 0755 /usr/local/bin/waterflow \
+    && cat > /usr/local/share/actl-waterflow-shell-init.sh <<'EOF'
+# Keep the baked WaterFlow virtualenv active while letting ACTL's synced checkout
+# at /home/dev/workspace override the baked /app source for edits.
+if [ -d /app/.venv/bin ]; then
+  VIRTUAL_ENV=/app/.venv
+  export VIRTUAL_ENV
+  case ":${PATH}:" in
+    *:/app/.venv/bin:*) ;;
+    *) PATH="/app/.venv/bin:${PATH}" ;;
+  esac
+  export PATH
+fi
+
+if [ -d /home/dev/workspace ]; then
+  case ":${PYTHONPATH:-}:" in
+    *:/home/dev/workspace:*) ;;
+    *) PYTHONPATH="/home/dev/workspace${PYTHONPATH:+:${PYTHONPATH}}" ;;
+  esac
+fi
+if [ -d /app ]; then
+  case ":${PYTHONPATH:-}:" in
+    *:/app:*) ;;
+    *) PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}/app" ;;
+  esac
+fi
+export PYTHONPATH
+
+if [ -d /mnt/diffuse-shared ]; then
+  mkdir -p \
+    /mnt/diffuse-shared/waterflow/pdb \
+    /mnt/diffuse-shared/waterflow/cache \
+    /mnt/diffuse-shared/waterflow/checkpoints \
+    /mnt/diffuse-shared/waterflow/outputs \
+    /mnt/diffuse-shared/waterflow/logs \
+    /mnt/diffuse-shared/waterflow/splits 2>/dev/null || true
+fi
+
+case "$-" in
+  *i*)
+    if [ -d /home/dev/workspace ]; then
+      cd /home/dev/workspace || true
+    fi
+    ;;
+esac
+EOF
+RUN chmod 0644 /usr/local/share/actl-waterflow-shell-init.sh \
+    && printf '\n# Astera WaterFlow environment\n[ -r /usr/local/share/actl-waterflow-shell-init.sh ] && . /usr/local/share/actl-waterflow-shell-init.sh\n' >> /etc/bash.bashrc \
+    && printf '\n# Astera WaterFlow environment\n[ -r /usr/local/share/actl-waterflow-shell-init.sh ] && . /usr/local/share/actl-waterflow-shell-init.sh\n' >> /etc/zsh/zshrc \
+    && for cmd in waterflow python rsync tini vim nano emacs zsh; do command -v "${cmd}" >/dev/null; done
+
+WORKDIR /home/dev
+ENTRYPOINT []
+CMD ["bash"]

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -10,7 +10,7 @@
 #   docker buildx build --platform linux/amd64 \
 #     -f Dockerfile.astera \
 #     --build-arg WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc \
-#     -t harbor.astera.sh/library/waterflow:main-actl-2026-06-09 \
+#     -t "$ASTERA_REGISTRY/library/waterflow:main-actl-2026-06-09" \
 #     .
 
 ARG WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Predicting water molecule placements on protein surfaces using flow matching con
 The Astera ACTL overlay image is published as:
 
 ```bash
-harbor.astera.sh/library/waterflow:main-actl-2026-06-08
+harbor.astera.sh/library/waterflow:main-actl-2026-06-09
 ```
 
 Once the ACTL catalog alias is available, launch from this checkout with:
@@ -21,7 +21,7 @@ Before the alias lands, use the full image reference:
 
 ```bash
 actl pod up waterflow --profile single \
-  --image harbor.astera.sh/library/waterflow:main-actl-2026-06-08 \
+  --image harbor.astera.sh/library/waterflow:main-actl-2026-06-09 \
   --pvc-size 100Gi -n diffuse --yes
 ```
 
@@ -55,7 +55,7 @@ To build the ACTL overlay locally:
 docker buildx build --platform linux/amd64 \
   -f Dockerfile.astera \
   --build-arg WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc \
-  -t harbor.astera.sh/library/waterflow:main-actl-2026-06-08 \
+  -t harbor.astera.sh/library/waterflow:main-actl-2026-06-09 \
   .
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,63 @@
 
 Predicting water molecule placements on protein surfaces using flow matching conditioned on learned protein structure embeddings.
 
+## Running on ACTL
+
+The Astera ACTL overlay image is published as:
+
+```bash
+harbor.astera.sh/library/waterflow:main-actl-2026-06-08
+```
+
+Once the ACTL catalog alias is available, launch from this checkout with:
+
+```bash
+actl pod profiles -n diffuse
+actl pod up waterflow --profile single --image waterflow --pvc-size 100Gi -n diffuse --yes
+```
+
+Before the alias lands, use the full image reference:
+
+```bash
+actl pod up waterflow --profile single \
+  --image harbor.astera.sh/library/waterflow:main-actl-2026-06-08 \
+  --pvc-size 100Gi -n diffuse --yes
+```
+
+The selected diffuse profile auto-mounts the shared volume at `/mnt/diffuse-shared`. The ACTL image exposes `/mnt/diffuse-shared/waterflow` as `/data`, so the container defaults are persistent:
+
+```text
+/data/pdb          # input PDB tree
+/data/cache        # preprocessed geometry/ESM/SLAE caches
+/data/checkpoints  # training checkpoints
+/data/outputs      # inference outputs
+/data/logs         # W&B/offline logs
+/data/splits       # train/val/test split files
+```
+
+Inside the ACTL shell:
+
+```bash
+waterflow train \
+  --encoder_type gvp \
+  --train_list /data/splits/train_list_0.95.txt \
+  --val_list /data/splits/valid_list_0.05.txt \
+  --batch_size 4
+```
+
+`waterflow` uses the synced checkout under `/home/dev/workspace` when available,
+so edits to `src/` and `scripts/` are picked up without rebuilding the image.
+
+To build the ACTL overlay locally:
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -f Dockerfile.astera \
+  --build-arg WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc \
+  -t harbor.astera.sh/library/waterflow:main-actl-2026-06-08 \
+  .
+```
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,26 +4,28 @@ Predicting water molecule placements on protein surfaces using flow matching con
 
 ## Running on ACTL
 
-The Astera ACTL overlay image is published as:
-
-```bash
-harbor.astera.sh/library/waterflow:main-actl-2026-06-09
-```
-
-Once the ACTL catalog alias is available, launch from this checkout with:
+The Astera ACTL overlay image is in the actl catalog as the `waterflow` alias,
+scoped to the diffuse namespace. Launch from this checkout with:
 
 ```bash
 actl pod profiles -n diffuse
 actl pod up waterflow --profile single --image waterflow --pvc-size 100Gi -n diffuse --yes
 ```
 
-Before the alias lands, use the full image reference:
+The alias is the supported way in: it resolves to the current published tag for
+you, so nothing here has to be updated when that tag moves. Run `actl pod images`
+to see what it points at.
+
+If you need the raw reference (a `docker pull` outside actl, say), it is:
 
 ```bash
-actl pod up waterflow --profile single \
-  --image harbor.astera.sh/library/waterflow:main-actl-2026-06-09 \
-  --pvc-size 100Gi -n diffuse --yes
+$ASTERA_REGISTRY/library/waterflow:main-actl-2026-06-09
 ```
+
+`$ASTERA_REGISTRY` is Astera's internal Harbor host. It is deliberately not
+spelled out here because this repository is public. `actl pod images` prints the
+resolved reference, and CI reads the host from the `ASTERA_REGISTRY` repository
+secret.
 
 The selected diffuse profile auto-mounts the shared volume at `/mnt/diffuse-shared`. The ACTL image exposes `/mnt/diffuse-shared/waterflow` as `/data`, so the container defaults are persistent:
 
@@ -55,7 +57,7 @@ To build the ACTL overlay locally:
 docker buildx build --platform linux/amd64 \
   -f Dockerfile.astera \
   --build-arg WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow:latest@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc \
-  -t harbor.astera.sh/library/waterflow:main-actl-2026-06-09 \
+  -t "$ASTERA_REGISTRY/library/waterflow:main-actl-2026-06-09" \
   .
 ```
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,11 @@
 
 set -e
 
+# ACTL overlays sync the editable checkout to /home/dev/workspace while the
+# production image keeps the baked source in /app. Let the wrapper select the
+# source tree without changing normal Docker behavior.
+APP_DIR="${WATERFLOW_APP_DIR:-/app}"
+
 # Show help if no arguments
 show_help() {
     cat << EOF
@@ -59,7 +64,7 @@ COMMAND="${1:-}"
 case "$COMMAND" in
     train)
         shift
-        exec python /app/scripts/train.py \
+        exec python "${APP_DIR}/scripts/train.py" \
             --base_pdb_dir "${WATERFLOW_PDB_DIR}" \
             --processed_dir "${WATERFLOW_CACHE_DIR}" \
             --save_dir "${WATERFLOW_CHECKPOINT_DIR}" \
@@ -69,7 +74,7 @@ case "$COMMAND" in
 
     inference)
         shift
-        exec python /app/scripts/inference.py \
+        exec python "${APP_DIR}/scripts/inference.py" \
             --base_pdb_dir "${WATERFLOW_PDB_DIR}" \
             --processed_dir "${WATERFLOW_CACHE_DIR}" \
             --output_dir "${WATERFLOW_OUTPUT_DIR}" \
@@ -78,7 +83,7 @@ case "$COMMAND" in
 
     generate-esm)
         shift
-        exec python /app/scripts/generate_esm_embeddings.py \
+        exec python "${APP_DIR}/scripts/generate_esm_embeddings.py" \
             --base_pdb_dir "${WATERFLOW_PDB_DIR}" \
             --cache_dir "${WATERFLOW_CACHE_DIR}" \
             "$@"


### PR DESCRIPTION
## Summary
- add an Astera ACTL overlay Dockerfile and Harbor publish workflow for WaterFlow
- document ACTL launch commands, shared data layout, and local build command
- let the WaterFlow entrypoint target the ACTL-synced checkout via WATERFLOW_APP_DIR
- add .actlignore entries for large experiment artifacts
- preinstall ACTL network/debug tools: curl, wget, htop, tmux, ncdu, ping, and dig

## Image
- target tag: `harbor.astera.sh/library/waterflow:main-actl-2026-06-09`
- previous published tag verified: `harbor.astera.sh/library/waterflow:main-actl-2026-06-08` (`sha256:9c0ea3fad090a2a0324452189f3f1f21fd4e5f343f1655df55bd54591fab253c`)

## Related
- Catalog alias/tag update: Astera-org/asteractl#74

## Validation
- git diff --check
- bash -n docker/entrypoint.sh
- ruby YAML parse for .github/workflows/astera-docker.yml
