### PR TITLE
bf16 AMP + fused AdamW for flow and confidence trainers

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1146,9 +1146,7 @@ def main():
 
     # Resolve AMP once: it needs a CUDA device with bf16 support. Write the
     # verdict back to args so the recorded config.json reflects what actually ran.
-    if args.use_amp and (
-        device.type != "cuda" or not torch.cuda.is_bf16_supported()
-    ):
+    if args.use_amp and (device.type != "cuda" or not torch.cuda.is_bf16_supported()):
         reason = (
             "device is not CUDA"
             if device.type != "cuda"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1144,8 +1144,18 @@ def main():
     else:
         device = torch.device(args.device if torch.cuda.is_available() else "cpu")
 
-    if args.use_amp and device.type != "cuda":
-        logger.warning("--use_amp set but device is not CUDA; training without AMP.")
+    # Resolve AMP once: it needs a CUDA device with bf16 support. Write the
+    # verdict back to args so the recorded config.json reflects what actually ran.
+    if args.use_amp and (
+        device.type != "cuda" or not torch.cuda.is_bf16_supported()
+    ):
+        reason = (
+            "device is not CUDA"
+            if device.type != "cuda"
+            else "the GPU lacks bfloat16 support"
+        )
+        logger.warning(f"--use_amp set but {reason}; training without AMP.")
+        args.use_amp = False
 
     if args.run_name is None:
         args.run_name = generate_run_name(args)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -385,6 +385,20 @@ def parse_args():
     )
     p.add_argument("--step_gamma", type=float, default=0.5, help="StepLR gamma")
 
+    # mixed precision / optimizer
+    p.add_argument(
+        "--use_amp",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run the training forward pass under bfloat16 autocast (CUDA only). "
+        "On by default; pass --no-use_amp to disable.",
+    )
+    p.add_argument(
+        "--fused_adamw",
+        action="store_true",
+        help="Use the fused AdamW implementation (CUDA only).",
+    )
+
     # checkpointing
     p.add_argument("--save_dir", type=str, default="/home/srivasv/flow_checkpoints")
     p.add_argument(
@@ -1130,6 +1144,9 @@ def main():
     else:
         device = torch.device(args.device if torch.cuda.is_available() else "cpu")
 
+    if args.use_amp and device.type != "cuda":
+        logger.warning("--use_amp set but device is not CUDA; training without AMP.")
+
     if args.run_name is None:
         args.run_name = generate_run_name(args)
 
@@ -1285,12 +1302,15 @@ def main():
     flow_matcher = FlowMatcher(
         model=model,
         sampling_strategy=args.sampling_strategy,
+        use_amp=args.use_amp,
     )
 
+    # fused AdamW is a CUDA-only kernel; it silently requires all params on GPU.
     optimizer = AdamW(
         [p for p in raw_model.parameters() if p.requires_grad],
         lr=args.lr,
         weight_decay=args.weight_decay,
+        fused=args.fused_adamw and device.type == "cuda",
     )
     warmup_scheduler, main_scheduler = build_scheduler(optimizer, args)
 

--- a/scripts/train_confidence.py
+++ b/scripts/train_confidence.py
@@ -191,6 +191,18 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--lr", type=float, default=1e-4)
     p.add_argument("--weight_decay", type=float, default=1e-5)
     p.add_argument("--grad_clip", type=float, default=1.0)
+    p.add_argument(
+        "--use_amp",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run the training forward pass under bfloat16 autocast (CUDA only). "
+        "On by default; pass --no-use_amp to disable.",
+    )
+    p.add_argument(
+        "--fused_adamw",
+        action="store_true",
+        help="Use the fused AdamW implementation (CUDA only).",
+    )
     p.add_argument("--warmup_steps", type=int, default=500)
     p.add_argument(
         "--eta_min_factor",
@@ -470,6 +482,7 @@ def train_one_epoch(
     total_loss, total_n = 0.0, 0
     params = [p for group in optimizer.param_groups for p in group["params"]]
     accum = max(1, args.grad_accum_steps)
+    use_amp = getattr(args, "use_amp", True) and device.type == "cuda"
     # Bound to the wrapper, since only DDP defers the gradient all-reduce.
     no_sync = model.no_sync if isinstance(model, DDP) else None
     n_batches = len(loader)  # Equal across ranks: DistributedSampler + drop_last.
@@ -493,12 +506,15 @@ def train_one_epoch(
             # reducer is armed inside DDP.forward, so a rank that skipped it would
             # never all-reduce and would hang the others. On empty batches the
             # model returns a connected (0,) tensor, so this backward is a no-op.
-            preds = model(batch, return_logits=True)
-            loss = (
-                preds.sum()
-                if is_empty
-                else F.binary_cross_entropy_with_logits(preds, target)
-            )
+            with torch.autocast(
+                device_type="cuda", dtype=torch.bfloat16, enabled=use_amp
+            ):
+                preds = model(batch, return_logits=True)
+                loss = (
+                    preds.sum()
+                    if is_empty
+                    else F.binary_cross_entropy_with_logits(preds, target)
+                )
             (loss / accum).backward()
 
         if is_boundary:
@@ -555,6 +571,7 @@ def validate(
         _unwrap(model), training=False, freeze_backbone_enabled=args.freeze_backbone
     )
     total_loss, total_n, abs_err = 0.0, 0, 0.0
+    use_amp = getattr(args, "use_amp", True) and device.type == "cuda"
     score_chunks: list[torch.Tensor] = []
     label_chunks: list[torch.Tensor] = []
 
@@ -565,8 +582,9 @@ def validate(
         target = batch["water"].target_confidence
         if target.numel() == 0:
             continue
-        preds = model(batch, return_logits=True)
-        loss = F.binary_cross_entropy_with_logits(preds, target)
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=use_amp):
+            preds = model(batch, return_logits=True)
+            loss = F.binary_cross_entropy_with_logits(preds, target)
         # MAE is reported in probability space, for interpretability.
         probs = torch.sigmoid(preds)
         abs_err += (probs - target).abs().sum().item()
@@ -627,6 +645,8 @@ def main() -> None:
         if distributed
         else torch.device(args.device if torch.cuda.is_available() else "cpu")
     )
+    if args.use_amp and device.type != "cuda":
+        logger.warning("--use_amp set but device is not CUDA; training without AMP.")
 
     run_dir = Path(args.save_dir) / args.run_name
     # Rank 0 owns the run dir; the others wait so it exists before they touch it.
@@ -700,7 +720,13 @@ def main() -> None:
             find_unused_parameters=True,
         )
 
-    optimizer = AdamW(trainable_params, lr=args.lr, weight_decay=args.weight_decay)
+    # fused AdamW is a CUDA-only kernel; it silently requires all params on GPU.
+    optimizer = AdamW(
+        trainable_params,
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+        fused=args.fused_adamw and device.type == "cuda",
+    )
     warmup_scheduler = (
         LinearLR(
             optimizer, start_factor=1e-8, end_factor=1.0, total_iters=args.warmup_steps

--- a/scripts/train_confidence.py
+++ b/scripts/train_confidence.py
@@ -482,7 +482,7 @@ def train_one_epoch(
     total_loss, total_n = 0.0, 0
     params = [p for group in optimizer.param_groups for p in group["params"]]
     accum = max(1, args.grad_accum_steps)
-    use_amp = getattr(args, "use_amp", True) and device.type == "cuda"
+    use_amp = args.use_amp
     # Bound to the wrapper, since only DDP defers the gradient all-reduce.
     no_sync = model.no_sync if isinstance(model, DDP) else None
     n_batches = len(loader)  # Equal across ranks: DistributedSampler + drop_last.
@@ -571,7 +571,7 @@ def validate(
         _unwrap(model), training=False, freeze_backbone_enabled=args.freeze_backbone
     )
     total_loss, total_n, abs_err = 0.0, 0, 0.0
-    use_amp = getattr(args, "use_amp", True) and device.type == "cuda"
+    use_amp = args.use_amp
     score_chunks: list[torch.Tensor] = []
     label_chunks: list[torch.Tensor] = []
 
@@ -586,7 +586,9 @@ def validate(
             preds = model(batch, return_logits=True)
             loss = F.binary_cross_entropy_with_logits(preds, target)
         # MAE is reported in probability space, for interpretability.
-        probs = torch.sigmoid(preds)
+        # Cast logits to fp32 before sigmoid: under bf16 autocast preds is bf16,
+        # and these probs drive MAE, AUC-PR, and best-F1 (which selects the ckpt).
+        probs = torch.sigmoid(preds.float())
         abs_err += (probs - target).abs().sum().item()
         total_loss += loss.item() * target.size(0)
         total_n += target.size(0)
@@ -645,8 +647,18 @@ def main() -> None:
         if distributed
         else torch.device(args.device if torch.cuda.is_available() else "cpu")
     )
-    if args.use_amp and device.type != "cuda":
-        logger.warning("--use_amp set but device is not CUDA; training without AMP.")
+    # Resolve AMP once: it needs a CUDA device with bf16 support. Write the
+    # verdict back to args so the recorded config.json reflects what actually ran.
+    if args.use_amp and (
+        device.type != "cuda" or not torch.cuda.is_bf16_supported()
+    ):
+        reason = (
+            "device is not CUDA"
+            if device.type != "cuda"
+            else "the GPU lacks bfloat16 support"
+        )
+        logger.warning(f"--use_amp set but {reason}; training without AMP.")
+        args.use_amp = False
 
     run_dir = Path(args.save_dir) / args.run_name
     # Rank 0 owns the run dir; the others wait so it exists before they touch it.

--- a/scripts/train_confidence.py
+++ b/scripts/train_confidence.py
@@ -649,9 +649,7 @@ def main() -> None:
     )
     # Resolve AMP once: it needs a CUDA device with bf16 support. Write the
     # verdict back to args so the recorded config.json reflects what actually ran.
-    if args.use_amp and (
-        device.type != "cuda" or not torch.cuda.is_bf16_supported()
-    ):
+    if args.use_amp and (device.type != "cuda" or not torch.cuda.is_bf16_supported()):
         reason = (
             "device is not CUDA"
             if device.type != "cuda"

--- a/src/flow.py
+++ b/src/flow.py
@@ -940,11 +940,16 @@ class FlowMatcher:
         self.sampling_strategy = sampling_strategy
 
     def _autocast_context(self, device: torch.device):
-        """bf16 autocast on CUDA when --use_amp is set; a no-op otherwise."""
+        """bf16 autocast when use_amp is set and the device is a bf16-capable CUDA
+        GPU; a no-op otherwise. Guards every caller, including direct construction.
+        """
+        enabled = (
+            self.use_amp
+            and device.type == "cuda"
+            and torch.cuda.is_bf16_supported()
+        )
         return torch.autocast(
-            device_type="cuda",
-            dtype=torch.bfloat16,
-            enabled=self.use_amp and device.type == "cuda",
+            device_type="cuda", dtype=torch.bfloat16, enabled=enabled
         )
 
     @staticmethod

--- a/src/flow.py
+++ b/src/flow.py
@@ -1134,17 +1134,19 @@ class FlowMatcher:
 
         x_t = (1.0 - t_per_atom) * x0_star + t_per_atom * x1_star
 
-        # forward pass under bf16 autocast (CUDA only); loss is reduced in fp32
+        # forward pass under bf16 autocast (CUDA only); cast back to fp32 so the
+        # loss and RMSD below run in full precision
         batch["water"].pos = x_t
         with self._autocast_context(device):
             v_pred = self.model(batch, t)
+        v_pred = v_pred.float()
 
         # target velocity
         v_target = x1_star - x0_star
 
         # weighted MSE loss (upweight near t=1), reduced in fp32
         w = 1.0 / (self.loss_eps + (1.0 - t_per_atom))
-        per_atom_mse = (v_pred.float() - v_target).pow(2).mean(dim=-1, keepdim=True)
+        per_atom_mse = (v_pred - v_target).pow(2).mean(dim=-1, keepdim=True)
         loss = (w * per_atom_mse).sum() / w.sum()
 
         # training RMSD
@@ -1213,11 +1215,12 @@ class FlowMatcher:
         batch["water"].pos = x_t
         with self._autocast_context(device):
             v_pred = self.model(batch, t)
+        v_pred = v_pred.float()
 
         v_target = x1_star - x0_star
 
         w = 1.0 / (self.loss_eps + (1.0 - t_per_atom))
-        per_atom_mse = (v_pred.float() - v_target).pow(2).mean(dim=-1, keepdim=True)
+        per_atom_mse = (v_pred - v_target).pow(2).mean(dim=-1, keepdim=True)
         loss = (w * per_atom_mse).sum() / w.sum()
 
         # GPU RMSD

--- a/src/flow.py
+++ b/src/flow.py
@@ -901,6 +901,7 @@ class FlowMatcher:
         model,
         loss_eps: float = 1e-3,
         sampling_strategy: str = "uniform_ball",
+        use_amp: bool = False,
     ):
         """
         Initialize flow matcher for training and inference.
@@ -911,6 +912,8 @@ class FlowMatcher:
             sampling_strategy: Source distribution for flow matching noise.
                 "uniform_ball" samples uniformly in balls around protein atoms.
                 "scaled_gaussian" samples from N(0, sigma^2*I).
+            use_amp: Run forward passes under bfloat16 autocast (CUDA only). The
+                loss is still reduced in fp32, so it is a no-op off CUDA.
 
         Note:
             Edge construction is configured on the model, not here, so training
@@ -923,6 +926,7 @@ class FlowMatcher:
             )
         self.model = model
         self.loss_eps = loss_eps
+        self.use_amp = use_amp
         # Read the graph cutoff off the flow model. Under DDP the attribute lives
         # on the wrapped `.module` (DDP does not forward attribute lookups), so
         # fall through to it; otherwise a DDP run would silently use the default
@@ -934,6 +938,14 @@ class FlowMatcher:
         else:
             self.graph_cutoff = DEFAULT_EDGE_CUTOFF
         self.sampling_strategy = sampling_strategy
+
+    def _autocast_context(self, device: torch.device):
+        """bf16 autocast on CUDA when --use_amp is set; a no-op otherwise."""
+        return torch.autocast(
+            device_type="cuda",
+            dtype=torch.bfloat16,
+            enabled=self.use_amp and device.type == "cuda",
+        )
 
     @staticmethod
     def _num_graphs(data: HeteroData | Batch) -> int:
@@ -1122,16 +1134,17 @@ class FlowMatcher:
 
         x_t = (1.0 - t_per_atom) * x0_star + t_per_atom * x1_star
 
-        # forward pass
+        # forward pass under bf16 autocast (CUDA only); loss is reduced in fp32
         batch["water"].pos = x_t
-        v_pred = self.model(batch, t)
+        with self._autocast_context(device):
+            v_pred = self.model(batch, t)
 
         # target velocity
         v_target = x1_star - x0_star
 
-        # weighted MSE loss (upweight near t=1)
+        # weighted MSE loss (upweight near t=1), reduced in fp32
         w = 1.0 / (self.loss_eps + (1.0 - t_per_atom))
-        per_atom_mse = (v_pred - v_target).pow(2).mean(dim=-1, keepdim=True)
+        per_atom_mse = (v_pred.float() - v_target).pow(2).mean(dim=-1, keepdim=True)
         loss = (w * per_atom_mse).sum() / w.sum()
 
         # training RMSD
@@ -1198,12 +1211,13 @@ class FlowMatcher:
         x_t = (1.0 - t_per_atom) * x0_star + t_per_atom * x1_star
 
         batch["water"].pos = x_t
-        v_pred = self.model(batch, t)
+        with self._autocast_context(device):
+            v_pred = self.model(batch, t)
 
         v_target = x1_star - x0_star
 
         w = 1.0 / (self.loss_eps + (1.0 - t_per_atom))
-        per_atom_mse = (v_pred - v_target).pow(2).mean(dim=-1, keepdim=True)
+        per_atom_mse = (v_pred.float() - v_target).pow(2).mean(dim=-1, keepdim=True)
         loss = (w * per_atom_mse).sum() / w.sum()
 
         # GPU RMSD

--- a/src/flow.py
+++ b/src/flow.py
@@ -944,13 +944,9 @@ class FlowMatcher:
         GPU; a no-op otherwise. Guards every caller, including direct construction.
         """
         enabled = (
-            self.use_amp
-            and device.type == "cuda"
-            and torch.cuda.is_bf16_supported()
+            self.use_amp and device.type == "cuda" and torch.cuda.is_bf16_supported()
         )
-        return torch.autocast(
-            device_type="cuda", dtype=torch.bfloat16, enabled=enabled
-        )
+        return torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=enabled)
 
     @staticmethod
     def _num_graphs(data: HeteroData | Batch) -> int:

--- a/tests/test_train_confidence.py
+++ b/tests/test_train_confidence.py
@@ -42,6 +42,7 @@ def _train_args(**overrides):
         warmup_steps=0,
         freeze_backbone=True,
         grad_accum_steps=1,
+        use_amp=False,
     )
     return argparse.Namespace(**{**vars(args), **overrides})
 


### PR DESCRIPTION
Adding mixed precision (bfloat16) toggles in all training scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CUDA bfloat16 automatic mixed precision for training and validation, enabled by default.
  * Added an option to enable fused AdamW optimization on CUDA-compatible hardware.
  * Added command-line controls to disable mixed precision when needed.

* **Bug Fixes**
  * Training automatically falls back to standard precision and optimizer behavior on non-CUDA devices.
  * Loss calculations remain stable by using full precision for final comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->