### PR TITLE
feat(actl): add current WaterFlow overlay

### DIFF
--- a/.actlignore
+++ b/.actlignore
@@ -1,0 +1,15 @@
+# Keep experiment artifacts on the diffuse shared volume, not in the synced
+# source checkout.
+data/
+flow_cache/
+wandb/
+logs/
+outputs/
+checkpoints/
+*.ckpt
+*.h5
+*.hdf5
+*.pt
+*.pth
+*.safetensors
+*.wandb

--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -32,31 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Build ACTL overlay
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.astera
-          platforms: linux/amd64
-          load: true
-          push: false
-          tags: waterflow-actl:validate
-          build-args: |
-            WATERFLOW_BASE_IMAGE=${{ env.WATERFLOW_BASE_IMAGE }}
-      - name: Smoke-test ACTL wrapper
+      - name: Validate overlay scripts and inputs
         run: |
           set -euo pipefail
-          docker run --rm --entrypoint bash waterflow-actl:validate -lc '
-            test -L /data
-            test "$(readlink /data)" = /mnt/diffuse-shared/waterflow
-            test -x /usr/local/bin/waterflow
-            python -c "import sklearn; import src.utils"
-          '
-          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow --help
-          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow train --help
-          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow inference --help
-          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow generate-esm --help
+          bash -n docker/entrypoint.sh docker/actl-shell-init.sh docker/actl-waterflow
+          grep -q '^ENTRYPOINT \[\]$' Dockerfile.astera
+          grep -q '^CMD \["bash"\]$' Dockerfile.astera
+          grep -q '^WATERFLOW_BASE_IMAGE=' Dockerfile.astera
 
   publish:
     if: github.event_name != 'pull_request'
@@ -82,6 +64,12 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to Harbor
         uses: docker/login-action@v3
         with:
@@ -103,3 +91,18 @@ jobs:
           cache-from: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max
           provenance: false
+      - name: Smoke-test published image
+        run: |
+          set -euo pipefail
+          image="${ASTERA_REGISTRY}/${ASTERA_IMAGE_NAME}:sha-${GITHUB_SHA}"
+          docker pull "$image"
+          docker run --rm --entrypoint bash "$image" -lc '
+            test -L /data
+            test "$(readlink /data)" = /mnt/diffuse-shared/waterflow
+            test -x /usr/local/bin/waterflow
+            python -c "import sklearn; import src.utils"
+          '
+          docker run --rm -v "$GITHUB_WORKSPACE:/home/dev/workspace:ro" "$image" waterflow --help
+          docker run --rm -v "$GITHUB_WORKSPACE:/home/dev/workspace:ro" "$image" waterflow train --help
+          docker run --rm -v "$GITHUB_WORKSPACE:/home/dev/workspace:ro" "$image" waterflow inference --help
+          docker run --rm -v "$GITHUB_WORKSPACE:/home/dev/workspace:ro" "$image" waterflow generate-esm --help

--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -1,0 +1,105 @@
+name: WaterFlow ACTL image
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile.astera
+      - docker/actl-*
+      - docker/entrypoint.sh
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/astera-docker.yml
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.astera
+      - docker/actl-*
+      - docker/entrypoint.sh
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/astera-docker.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  WATERFLOW_BASE_IMAGE: docker.io/diffuseproject/waterflow@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build ACTL overlay
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.astera
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: waterflow-actl:validate
+          build-args: |
+            WATERFLOW_BASE_IMAGE=${{ env.WATERFLOW_BASE_IMAGE }}
+      - name: Smoke-test ACTL wrapper
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint bash waterflow-actl:validate -lc '
+            test -L /data
+            test "$(readlink /data)" = /mnt/diffuse-shared/waterflow
+            test -x /usr/local/bin/waterflow
+            python -c "import sklearn; import src.utils"
+          '
+          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow --help
+          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow train --help
+          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow inference --help
+          docker run --rm -v "$PWD:/home/dev/workspace:ro" waterflow-actl:validate waterflow generate-esm --help
+
+  publish:
+    if: github.event_name != 'pull_request'
+    needs: validate
+    runs-on: astera-sh-builder
+    env:
+      ASTERA_REGISTRY: ${{ secrets.ASTERA_REGISTRY }}
+      ASTERA_IMAGE_NAME: library/waterflow
+    steps:
+      - name: Verify registry configuration
+        run: |
+          set -euo pipefail
+          if [ -z "${ASTERA_REGISTRY}" ]; then
+            echo "ASTERA_REGISTRY repository secret must be set." >&2
+            exit 1
+          fi
+          case "${ASTERA_REGISTRY}" in
+            docker.io|index.docker.io|registry-1.docker.io)
+              echo "ASTERA_REGISTRY must be an internal registry." >&2
+              exit 1 ;;
+          esac
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ASTERA_REGISTRY }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+      - name: Build and publish ACTL overlay
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.astera
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:main-actl
+            ${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:sha-${{ github.sha }}
+          build-args: |
+            WATERFLOW_BASE_IMAGE=${{ env.WATERFLOW_BASE_IMAGE }}
+          cache-from: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max
+          provenance: false

--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -38,7 +38,7 @@ jobs:
           bash -n docker/entrypoint.sh docker/actl-shell-init.sh docker/actl-waterflow
           grep -q '^ENTRYPOINT \[\]$' Dockerfile.astera
           grep -q '^CMD \["bash"\]$' Dockerfile.astera
-          grep -q '^WATERFLOW_BASE_IMAGE=' Dockerfile.astera
+          grep -q '^ARG WATERFLOW_BASE_IMAGE=' Dockerfile.astera
 
   publish:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,28 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: testing
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install ruff
         run: pip install ruff
 
-      - name: Auto-fix with ruff
+      - name: Check formatting and lint
         run: |
-          ruff check --fix .
-          ruff format .
-
-      - name: Commit ruff fixes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "Auto-commit ruff fixes [skip ci]"
-          commit_username: "Autoformatter"
-          commit_email: "actions@github.com"
+          ruff check .
+          ruff format --check .
 
   ty:
     runs-on: ubuntu-latest

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+# WaterFlow ACTL overlay. The base provides CUDA, the gated ESM3 cache, and
+# /app/.venv; this layer updates its dependencies for this checkout and adds
+# interactive workspace tooling.
+ARG WATERFLOW_BASE_IMAGE=docker.io/diffuseproject/waterflow@sha256:cfa4d600c88adf5223814e2c1861de85bf6047fe279c0df44f44cb4a8e6c65dc
+FROM ${WATERFLOW_BASE_IMAGE}
+
+USER root
+
+ARG ACTL_PACKAGES="bash ca-certificates curl wget rsync tini vim nano emacs-nox git zsh htop tmux ncdu iputils-ping dnsutils"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/home/dev \
+    XDG_CONFIG_HOME=/home/dev/.config \
+    XDG_CACHE_HOME=/home/dev/.cache \
+    XDG_DATA_HOME=/home/dev/.local/share \
+    SHELL=/bin/bash \
+    VIRTUAL_ENV=/app/.venv \
+    PATH=/app/.venv/bin:${PATH} \
+    PYTHONPATH=/home/dev/workspace:/app \
+    WATERFLOW_PDB_DIR=/data/pdb \
+    WATERFLOW_CACHE_DIR=/data/cache \
+    WATERFLOW_CHECKPOINT_DIR=/data/checkpoints \
+    WATERFLOW_OUTPUT_DIR=/data/outputs \
+    WATERFLOW_LOG_DIR=/data/logs \
+    WATERFLOW_SPLITS_DIR=/data/splits
+
+COPY pyproject.toml uv.lock /app/
+RUN cd /app && uv sync --frozen --no-install-project
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ${ACTL_PACKAGES} \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /home/dev/.config /home/dev/.cache /home/dev/.local/share /home/dev/workspace /etc/zsh \
+    && rm -rf /data \
+    && ln -s /mnt/diffuse-shared/waterflow /data
+
+COPY docker/entrypoint.sh /app/entrypoint.sh
+COPY docker/actl-shell-init.sh /usr/local/share/actl-waterflow-shell-init.sh
+COPY docker/actl-waterflow /usr/local/bin/waterflow
+
+RUN chmod 0755 /app/entrypoint.sh /usr/local/bin/waterflow \
+    && chmod 0644 /usr/local/share/actl-waterflow-shell-init.sh \
+    && printf '\n# Astera WaterFlow workspace\n[ -r /usr/local/share/actl-waterflow-shell-init.sh ] && . /usr/local/share/actl-waterflow-shell-init.sh\n' >> /etc/bash.bashrc \
+    && printf '\n# Astera WaterFlow workspace\n[ -r /usr/local/share/actl-waterflow-shell-init.sh ] && . /usr/local/share/actl-waterflow-shell-init.sh\n' >> /etc/zsh/zshrc \
+    && for cmd in waterflow python curl wget rsync tini vim nano emacs git zsh htop tmux ncdu ping dig; do command -v "${cmd}" >/dev/null; done
+
+WORKDIR /home/dev
+ENTRYPOINT []
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Predicting water molecule placements on protein surfaces using flow matching conditioned on learned protein structure embeddings.
 
+## ACTL
+
+In the diffuse namespace, launch the catalog image from this checkout:
+
+```sh
+actl pod up waterflow --profile single --image waterflow --pvc-size 100Gi -n diffuse --yes
+```
+
+The diffuse profile mounts shared storage at `/mnt/diffuse-shared`; the image
+exposes `/mnt/diffuse-shared/waterflow` as `/data` for PDBs, caches,
+checkpoints, outputs, logs, and optional split files. The checkout itself
+syncs to `/home/dev/workspace`, so its `splits/` directory is available without
+copying it to shared storage. The `waterflow` command uses the synced checkout
+when present, while preserving the image's virtual environment.
+
 ## Project Structure
 
 ```

--- a/docker/actl-shell-init.sh
+++ b/docker/actl-shell-init.sh
@@ -23,7 +23,9 @@ esac
 export PYTHONPATH
 
 if [ -d /mnt/diffuse-shared ]; then
-  mkdir -p /mnt/diffuse-shared/waterflow/{pdb,cache,checkpoints,outputs,logs,splits} 2>/dev/null || true
+  if ! mkdir -p /mnt/diffuse-shared/waterflow/{pdb,cache,checkpoints,outputs,logs,splits}; then
+    printf 'waterflow: warning: could not initialize shared storage under /mnt/diffuse-shared/waterflow\n' >&2
+  fi
 fi
 
 case "$-" in

--- a/docker/actl-shell-init.sh
+++ b/docker/actl-shell-init.sh
@@ -1,0 +1,31 @@
+# Keep the baked virtualenv active while a synced checkout overrides the baked
+# source tree for interactive ACTL work.
+if [ -d /app/.venv/bin ]; then
+  VIRTUAL_ENV=/app/.venv
+  export VIRTUAL_ENV
+  case ":${PATH}:" in
+    *:/app/.venv/bin:*) ;;
+    *) PATH="/app/.venv/bin:${PATH}" ;;
+  esac
+  export PATH
+fi
+
+if [ -d /home/dev/workspace ]; then
+  case ":${PYTHONPATH:-}:" in
+    *:/home/dev/workspace:*) ;;
+    *) PYTHONPATH="/home/dev/workspace${PYTHONPATH:+:${PYTHONPATH}}" ;;
+  esac
+fi
+case ":${PYTHONPATH:-}:" in
+  *:/app:*) ;;
+  *) PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}/app" ;;
+esac
+export PYTHONPATH
+
+if [ -d /mnt/diffuse-shared ]; then
+  mkdir -p /mnt/diffuse-shared/waterflow/{pdb,cache,checkpoints,outputs,logs,splits} 2>/dev/null || true
+fi
+
+case "$-" in
+  *i*) [ -d /home/dev/workspace ] && cd /home/dev/workspace || true ;;
+esac

--- a/docker/actl-waterflow
+++ b/docker/actl-waterflow
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 if [ -d /mnt/diffuse-shared ]; then
-  mkdir -p /mnt/diffuse-shared/waterflow/{pdb,cache,checkpoints,outputs,logs,splits} 2>/dev/null || true
+  if ! mkdir -p /mnt/diffuse-shared/waterflow/{pdb,cache,checkpoints,outputs,logs,splits}; then
+    printf 'waterflow: warning: could not initialize shared storage under /mnt/diffuse-shared/waterflow\n' >&2
+  fi
 fi
 
-entrypoint=/app/entrypoint.sh
-if [ -x /home/dev/workspace/docker/entrypoint.sh ] && [ -d /home/dev/workspace/scripts ]; then
+if [ -d /home/dev/workspace/scripts ]; then
   export WATERFLOW_APP_DIR=/home/dev/workspace
-  entrypoint=/home/dev/workspace/docker/entrypoint.sh
 fi
 
-exec "${entrypoint}" "$@"
+exec /app/entrypoint.sh "$@"

--- a/docker/actl-waterflow
+++ b/docker/actl-waterflow
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d /mnt/diffuse-shared ]; then
+  mkdir -p /mnt/diffuse-shared/waterflow/{pdb,cache,checkpoints,outputs,logs,splits} 2>/dev/null || true
+fi
+
+entrypoint=/app/entrypoint.sh
+if [ -x /home/dev/workspace/docker/entrypoint.sh ] && [ -d /home/dev/workspace/scripts ]; then
+  export WATERFLOW_APP_DIR=/home/dev/workspace
+  entrypoint=/home/dev/workspace/docker/entrypoint.sh
+fi
+
+exec "${entrypoint}" "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,10 @@
 
 set -e
 
+# ACTL syncs an editable checkout to /home/dev/workspace while the image keeps
+# its baked source in /app.
+APP_DIR="${WATERFLOW_APP_DIR:-/app}"
+
 # Show help if no arguments
 show_help() {
     cat << EOF
@@ -59,7 +63,7 @@ COMMAND="${1:-}"
 case "$COMMAND" in
     train)
         shift
-        exec python /app/scripts/train.py \
+        exec python "${APP_DIR}/scripts/train.py" \
             --base_pdb_dir "${WATERFLOW_PDB_DIR}" \
             --processed_dir "${WATERFLOW_CACHE_DIR}" \
             --save_dir "${WATERFLOW_CHECKPOINT_DIR}" \
@@ -69,7 +73,7 @@ case "$COMMAND" in
 
     inference)
         shift
-        exec python /app/scripts/inference.py \
+        exec python "${APP_DIR}/scripts/inference.py" \
             --base_pdb_dir "${WATERFLOW_PDB_DIR}" \
             --processed_dir "${WATERFLOW_CACHE_DIR}" \
             --output_dir "${WATERFLOW_OUTPUT_DIR}" \
@@ -78,7 +82,7 @@ case "$COMMAND" in
 
     generate-esm)
         shift
-        exec python /app/scripts/generate_esm_embeddings.py \
+        exec python "${APP_DIR}/scripts/generate_esm_embeddings.py" \
             --base_pdb_dir "${WATERFLOW_PDB_DIR}" \
             --cache_dir "${WATERFLOW_CACHE_DIR}" \
             "$@"


### PR DESCRIPTION
## Summary
Supersedes #81 with an ACTL overlay built against current WaterFlow main.

## Impact
ACTL uses the synced checkout with refreshed dependencies and the baked ESM cache.

## Changes
- `Dockerfile.astera:5,28` updates the overlay and locked dependency sync.
- `docker/entrypoint.sh:10,62` supports synced source.
- `.github/workflows/astera-docker.yml:31,61` validates forks safely and builds/smoke-tests from main.
- `.github/workflows/lint.yml:12` fixes fork-PR linting.

## Testing
- Shell syntax, YAML parsing, Ruff check, and Ruff format check passed.

## Deployment
Main builds, publishes, and smoke-tests the SHA image; then pin it in actl.