### PR TITLE
Switch to mates-off model if symmetry information is missing/incorrect

### DIFF
--- a/scripts/predict_waters.py
+++ b/scripts/predict_waters.py
@@ -16,8 +16,9 @@ For esm/slae encoders the protein embeddings must already be in
 
 Models are loaded from a --ckpt_dir holding flow.pt, confidence.pt,
 flow_config.json and confidence_config.json. It defaults to the mates models
-shipped in the repo (checkpoints/mates); pass checkpoints/mates_off to run
-without symmetry mates.
+shipped in the repo (checkpoints/mates), or to checkpoints/mates_off when no
+input has usable crystal symmetry (predicted structures); pass a directory to
+choose one yourself.
 
 Usage (the default models use esm, so embeddings come first):
     python -m scripts.generate_esm_embeddings --struc protein.cif --processed_dir cache/
@@ -48,7 +49,7 @@ from tqdm import tqdm
 from scripts.inference import build_model_from_config, run_inference_batch
 from src.confidence import build_confidence_model, cluster_waters_vdw, ConfidenceGVP
 from src.confidence_dataset import _oxygen_features
-from src.dataset import parse_asu_with_biotite
+from src.dataset import crystal_symmetry_check, parse_asu_with_biotite
 from src.flow import FlowMatcher
 from src.inference_graph import build_inference_graph
 from src.structure_io import merge_waters, read_space_group, write_structure
@@ -317,6 +318,43 @@ def _collect_struc_paths(args: argparse.Namespace) -> list[str]:
     return paths
 
 
+def resolve_ckpt_dir(explicit: str | None, paths: list[str]) -> Path:
+    """Pick the checkpoint directory when the user did not name one.
+
+    The shipped mates models expect crystal symmetry in the input. When no
+    input has any, fall back to the shipped mates_off models so predicted
+    structures work out of the box. A mix of inputs with and without symmetry
+    is refused: one model cannot serve both, so such runs must be split.
+    """
+    if explicit is not None:
+        return Path(explicit)
+    errors = {p: crystal_symmetry_check(p) for p in paths}
+    bad = [p for p, why in errors.items() if why is not None]
+    if not bad:
+        return REPO_ROOT / "checkpoints" / "mates"
+    if len(bad) < len(paths):
+        names = [Path(p).name for p in bad]
+        raise ValueError(
+            f"Inputs mix structures with and without usable crystal symmetry "
+            f"({names} lack it); split them into separate runs."
+        )
+    off_dir = REPO_ROOT / "checkpoints" / "mates_off"
+    needed = ("flow.pt", "confidence.pt", "flow_config.json", "confidence_config.json")
+    missing = [f for f in needed if not (off_dir / f).exists()]
+    if missing:
+        raise ValueError(
+            f"No input has usable crystal symmetry and the mates_off fallback "
+            f"is missing {missing} under {off_dir}; pass --ckpt_dir with "
+            "models trained without mates."
+        )
+    example = bad[0]
+    logger.warning(
+        f"No input has usable crystal symmetry ({Path(example).name}: "
+        f"{errors[example]}); switching to the mates_off models"
+    )
+    return off_dir
+
+
 def _check_embeddings(
     paths: list[str], encoder_type: str, processed_dir: str | None
 ) -> None:
@@ -341,10 +379,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--ckpt_dir",
-        default=str(REPO_ROOT / "checkpoints" / "mates"),
+        default=None,
         help="Directory holding flow.pt, confidence.pt, flow_config.json and "
-        "confidence_config.json. Default: the mates models shipped in the repo; "
-        "pass checkpoints/mates_off to run without symmetry mates.",
+        "confidence_config.json. Default: the mates models shipped in the repo, "
+        "or the mates_off models when no input has usable crystal symmetry.",
     )
 
     src = p.add_mutually_exclusive_group(required=True)
@@ -439,7 +477,8 @@ def main() -> None:
     setup_logging_for_tqdm(level=args.log_level)
     device = torch.device(args.device if torch.cuda.is_available() else "cpu")
 
-    ckpt_dir = Path(args.ckpt_dir)
+    paths = _collect_struc_paths(args)
+    ckpt_dir = resolve_ckpt_dir(args.ckpt_dir, paths)
     flow_config = json.loads((ckpt_dir / "flow_config.json").read_text())
     conf_config = json.loads((ckpt_dir / "confidence_config.json").read_text())
     conf_config = conf_config.get("flow_config", conf_config)  # confidence runs nest it
@@ -461,7 +500,6 @@ def main() -> None:
             f"built for {flow_encoder!r}; use checkpoints whose encoders match."
         )
 
-    paths = _collect_struc_paths(args)
     _check_embeddings(paths, flow_encoder, args.processed_dir)
 
     # Cache subdir named by every setting that shapes its files, so runs with

--- a/scripts/predict_waters.py
+++ b/scripts/predict_waters.py
@@ -59,9 +59,6 @@ from src.utils import setup_logging_for_tqdm
 DEFAULT_CONFIDENCE_THRESHOLD = 0.5  # confidence mode
 DEFAULT_DENSITY_RATIO = 0.6  # density mode, waters per ASU residue
 
-# Anchor the shipped-checkpoint default to the repo, not the working directory.
-REPO_ROOT = Path(__file__).resolve().parents[1]
-
 
 # ---------------------------------------------------------------------------
 # Model loading
@@ -331,14 +328,14 @@ def resolve_ckpt_dir(explicit: str | None, paths: list[str]) -> Path:
     errors = {p: crystal_symmetry_check(p) for p in paths}
     bad = [p for p, why in errors.items() if why is not None]
     if not bad:
-        return REPO_ROOT / "checkpoints" / "mates"
+        return Path("checkpoints/mates")
     if len(bad) < len(paths):
         names = [Path(p).name for p in bad]
         raise ValueError(
             f"Inputs mix structures with and without usable crystal symmetry "
             f"({names} lack it); split them into separate runs."
         )
-    off_dir = REPO_ROOT / "checkpoints" / "mates_off"
+    off_dir = Path("checkpoints/mates_off")
     needed = ("flow.pt", "confidence.pt", "flow_config.json", "confidence_config.json")
     missing = [f for f in needed if not (off_dir / f).exists()]
     if missing:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -119,6 +119,32 @@ def parse_asu_with_biotite(
     return protein_atoms, water_atoms, ligand_atoms
 
 
+def crystal_symmetry_check(struc_path: str) -> str | None:
+    """Say why a file cannot produce symmetry mates, or return None if it can.
+
+    symexp silently yields nothing when the file has no symmetry record, and
+    yields stacked translational copies of the whole structure when the cell
+    is a placeholder (predicted and NMR files often carry CRYST1 1 1 1 P 1).
+    A real crystal cell has at least ~15 cubic Angstroms per atom, a
+    placeholder ~1 total, so a floor of 4 per atom separates them with wide
+    margin.
+    """
+    with pymol2.PyMOL() as pm:
+        cmd = pm.cmd
+        cmd.feedback("disable", "all", "everything")
+        obj = "struct"
+        cmd.load(struc_path, obj)
+        symmetry = cmd.get_symmetry(obj)
+        if symmetry is None:
+            return "no crystal symmetry record"
+        if symmetry[0] * symmetry[1] * symmetry[2] < 4.0 * cmd.count_atoms(obj):
+            return (
+                f"placeholder unit cell {symmetry[0]:g} x {symmetry[1]:g} x "
+                f"{symmetry[2]:g} too small to hold the structure"
+            )
+        return None
+
+
 def get_crystal_contacts_pymol(
     struc_path: str,
     cutoff: float = 5.0,
@@ -152,7 +178,19 @@ def get_crystal_contacts_pymol(
             - 'mate_ligand_coords': (M, 3) whole ligand-mate entities, empty
               unless include_ligands
             - 'mate_ligand_atoms': List of PyMOL atom objects for ligand mates
+
+    Raises:
+        ValueError: If the file has no symmetry record or only a placeholder
+            unit cell, as predicted and NMR structures do.
     """
+    error = crystal_symmetry_check(struc_path)
+    if error is not None:
+        raise ValueError(
+            f"{struc_path}: {error}; cannot build symmetry mates. Run "
+            "this structure with a model trained without mates, e.g. the "
+            "released mates_off checkpoints."
+        )
+
     with pymol2.PyMOL() as pm:
         cmd = pm.cmd
         cmd.reinitialize()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1105,9 +1105,40 @@ class TestLigandNodeIntegration:
         assert (data["protein"].residue_index[~lig_mask] >= 0).all()
 
 
+def write_minimal_pdb(path, cryst1=None):
+    """Write five CA atoms in a row, optionally under a CRYST1 record."""
+    lines = [cryst1] if cryst1 else []
+    for i in range(5):
+        lines.append(
+            f"ATOM  {i + 1:>5}  CA  ALA A{i + 1:>4}    "
+            f"{10.0 + 3.8 * i:8.3f}{10.0:8.3f}{10.0:8.3f}  1.00 20.00           C"
+        )
+    lines.append("END")
+    path.write_text("\n".join(lines) + "\n")
+    return str(path)
+
+
 @pytest.mark.integration
 class TestGetCrystalContactsPymol:
     """Tests for PyMOL crystal contact detection."""
+
+    def test_rejects_missing_symmetry_record(self, tmp_path):
+        """Without a CRYST1 record symexp would silently return nothing and
+        the graph would lack mates unnoticed, so the call must fail instead."""
+        pdb = write_minimal_pdb(tmp_path / "nocryst.pdb")
+        with pytest.raises(ValueError, match="no crystal symmetry record"):
+            get_crystal_contacts_pymol(pdb, cutoff=8.0)
+
+    def test_rejects_placeholder_cell(self, tmp_path):
+        """With the 1 A dummy cell that predicted structures carry, symexp
+        would tile the structure onto itself, so the call must fail instead."""
+        pdb = write_minimal_pdb(
+            tmp_path / "af_p1.pdb",
+            cryst1="CRYST1    1.000    1.000    1.000  90.00  90.00  90.00 "
+            "P 1           1",
+        )
+        with pytest.raises(ValueError, match="placeholder unit cell"):
+            get_crystal_contacts_pymol(pdb, cutoff=8.0)
 
     def test_returns_expected_keys(self, pdb_6eey):
         """Should return dictionary with expected keys."""

--- a/tests/test_predict_waters.py
+++ b/tests/test_predict_waters.py
@@ -20,6 +20,7 @@ from scripts.predict_waters import (
     load_checkpoint,
     parse_args,
     predict_structures,
+    resolve_ckpt_dir,
     select_waters,
 )
 from src.confidence import build_confidence_model, ConfidenceGVP
@@ -235,6 +236,37 @@ class TestCheckEmbeddings:
         emb.mkdir()
         (emb / "protein.pt").touch()
         _check_embeddings(["some/dir/protein.cif"], "esm", str(tmp_path))
+
+
+@pytest.mark.unit
+class TestResolveCkptDir:
+    def test_explicit_dir_skips_detection(self, monkeypatch):
+        def refuse(path):
+            raise AssertionError("detection must not run for an explicit dir")
+
+        monkeypatch.setattr("scripts.predict_waters.crystal_symmetry_check", refuse)
+        assert resolve_ckpt_dir("my_ckpts", ["a.pdb"]) == Path("my_ckpts")
+
+    def test_all_symmetric_picks_mates(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.predict_waters.crystal_symmetry_check", lambda p: None
+        )
+        assert resolve_ckpt_dir(None, ["a.pdb", "b.pdb"]).name == "mates"
+
+    def test_none_symmetric_falls_back_to_mates_off(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.predict_waters.crystal_symmetry_check",
+            lambda p: "no crystal symmetry record",
+        )
+        assert resolve_ckpt_dir(None, ["a.pdb", "b.pdb"]).name == "mates_off"
+
+    def test_mixed_inputs_are_refused(self, monkeypatch):
+        monkeypatch.setattr(
+            "scripts.predict_waters.crystal_symmetry_check",
+            lambda p: None if p == "good.pdb" else "no crystal symmetry record",
+        )
+        with pytest.raises(ValueError, match="mix"):
+            resolve_ckpt_dir(None, ["good.pdb", "af.pdb"])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Currently if the symmetry information is missing, the model predicts with the mates on model, just without mates nodes as context. Worse, if the file has bad symmetry (like placeholders), we get spurious mates nodes.

This PR adds a check for the symmetry mates quality and routes to the mates off model if the check fails. Addressing issue #114.