### PR TITLE
fix(ci): use hosted runner for ACTL publish

### DIFF
--- a/.github/workflows/astera-docker.yml
+++ b/.github/workflows/astera-docker.yml
@@ -43,7 +43,7 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: validate
-    runs-on: astera-sh-builder
+    runs-on: ubuntu-latest
     env:
       ASTERA_REGISTRY: ${{ secrets.ASTERA_REGISTRY }}
       ASTERA_IMAGE_NAME: library/waterflow
@@ -61,6 +61,10 @@ jobs:
               exit 1 ;;
           esac
       - uses: actions/checkout@v4
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          docker system prune -af
       - uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container


### PR DESCRIPTION
## Summary
Unblock the WaterFlow ACTL image publish job after #113.

## Changes
- run publish on `ubuntu-latest`, which this repository can access
- reclaim hosted-runner disk before pulling and layering the large WaterFlow image

## Context
The manually dispatched #113 release validated successfully, but its publish job remained queued for over 90 minutes with `runner_id=0` because `astera-sh-builder` is not assigned to this repository. The previous WaterFlow ACTL workflow ran on a GitHub-hosted runner.

## Testing
- workflow YAML parses
- overlay shell syntax and exact validation commands pass locally