### PR TITLE
Move scattered constants into constants.py

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -29,7 +29,7 @@ import torch.nn as nn
 from loguru import logger
 from tqdm import tqdm
 
-from src.constants import DEFAULT_EDGE_CUTOFF, NUM_RBF
+from src.constants import DEFAULT_EDGE_CUTOFF, DEFAULT_MIN_EDIA, NUM_RBF
 from src.dataset import ProteinWaterDataset
 from src.encoder_base import build_encoder, resolve_encoder_config
 from src.flow import FlowMatcher, FlowWaterGVP
@@ -211,7 +211,7 @@ def _extract_dataset_filter_config(config: dict) -> dict:
         "interface_dist_threshold": config.get("interface_dist_threshold", 4.0),
         "min_water_residue_ratio": config.get("min_water_residue_ratio", 0.1),
         "max_protein_dist": config.get("max_protein_dist", 5.0),
-        "min_edia": config.get("min_edia", 0.4),
+        "min_edia": config.get("min_edia", DEFAULT_MIN_EDIA),
         "max_bfactor_zscore": config.get("max_bfactor_zscore", 2.0),
         "filter_by_distance": config.get("filter_by_distance", True),
         "filter_by_edia": config.get("filter_by_edia", True),

--- a/scripts/predict_waters.py
+++ b/scripts/predict_waters.py
@@ -49,6 +49,7 @@ from tqdm import tqdm
 from scripts.inference import build_model_from_config, run_inference_batch
 from src.confidence import build_confidence_model, cluster_waters_vdw, ConfidenceGVP
 from src.confidence_dataset import _oxygen_features
+from src.constants import DEFAULT_EDGE_CUTOFF
 from src.dataset import crystal_symmetry_check, parse_asu_with_biotite
 from src.flow import FlowMatcher
 from src.inference_graph import build_inference_graph
@@ -199,7 +200,7 @@ def predict_structures(
                 processed_dir=args.processed_dir,
                 include_mates=args.include_mates,
                 include_ligands=flow_config.get("include_ligands", True),
-                cutoff=flow_config.get("cutoff", 8.0),
+                cutoff=flow_config.get("cutoff", DEFAULT_EDGE_CUTOFF),
                 max_neighbors=flow_config.get("max_neighbors", 256),
                 cache_dir=cache,
             )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -42,6 +42,7 @@ from torch.utils.data import DataLoader
 from torch_geometric.data import HeteroData
 from tqdm import tqdm
 
+from src.constants import DEFAULT_EDGE_CUTOFF, DEFAULT_MIN_EDIA
 from src.dataset import get_dataloader, ProteinWaterDataset
 from src.distributed import (
     all_reduce_means,
@@ -185,7 +186,7 @@ def parse_args():
     p.add_argument(
         "--min_edia",
         type=float,
-        default=0.4,
+        default=DEFAULT_MIN_EDIA,
         help="Water filter: remove waters with EDIA below this threshold.",
     )
     p.add_argument(
@@ -280,8 +281,8 @@ def parse_args():
     p.add_argument(
         "--cutoff",
         type=float,
-        default=8.0,
-        help="Distance cutoff in Angstroms for radius edges (default: 8.0)",
+        default=DEFAULT_EDGE_CUTOFF,
+        help=f"Distance cutoff in Angstroms for radius edges (default: {DEFAULT_EDGE_CUTOFF})",
     )
     p.add_argument(
         "--max_neighbors",

--- a/src/confidence.py
+++ b/src/confidence.py
@@ -22,7 +22,13 @@ import torch.nn.functional as F
 from torch import nn, Tensor
 from torch_geometric.data import HeteroData
 
-from src.constants import EDGE_PP, EDGE_PW, NUM_RBF
+from src.constants import (
+    DEFAULT_EDGE_CUTOFF,
+    EDGE_PP,
+    EDGE_PW,
+    NUM_RBF,
+    OXYGEN_VDW_RADIUS,
+)
 from src.encoder_base import BaseProteinEncoder, build_encoder, resolve_encoder_config
 from src.flow import ProteinWaterUpdate
 from src.gvp import GVP
@@ -136,9 +142,6 @@ def smootherstep_target(
 # ---------------------------------------------------------------------------
 # Post-processor
 # ---------------------------------------------------------------------------
-
-
-OXYGEN_VDW_RADIUS = 1.52  # Angstroms. Clustering and NMS radius for waters.
 
 
 def cluster_waters_vdw(
@@ -279,7 +282,7 @@ class ConfidenceGVP(nn.Module):
         n_message_gvps: int = 2,
         n_update_gvps: int = 2,
         vector_gate: bool = True,
-        cutoff: float = 8.0,
+        cutoff: float = DEFAULT_EDGE_CUTOFF,
         max_neighbors: int = 256,
         dynamic_edge_policy: str = "knn_if_isolated",
         knn_fallback_k: int = 8,
@@ -459,7 +462,7 @@ def build_confidence_model(config: dict, device: torch.device) -> ConfidenceGVP:
         drop_rate=config.get("drop_rate", 0.1),
         n_message_gvps=config.get("n_message_gvps", 2),
         n_update_gvps=config.get("n_update_gvps", 2),
-        cutoff=config.get("cutoff", 8.0),
+        cutoff=config.get("cutoff", DEFAULT_EDGE_CUTOFF),
         max_neighbors=config.get("max_neighbors", 256),
         knn_fallback_k=config.get("knn_fallback_k", 8),
         # Fixed, not from flow config: candidates are scored with no cached PW

--- a/src/confidence_dataset.py
+++ b/src/confidence_dataset.py
@@ -25,11 +25,8 @@ from torch.utils.data import Dataset
 from torch_geometric.data import HeteroData
 
 from src.confidence import nearest_gt_distance, smootherstep_confidence
-from src.constants import ELEM_IDX, NODE_FEATURE_DIM
+from src.constants import NODE_FEATURE_DIM, OXYGEN_INDEX
 from src.dataset import ProteinWaterDataset
-
-
-OXYGEN_INDEX = ELEM_IDX["O"]
 
 
 def _oxygen_features(n: int, device: torch.device | None = None) -> Tensor:

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,6 +19,15 @@ RBF_CUTOFF = 8.0  # Distance cutoff in Angstroms for RBF encoding
 # building edges beyond it would feed the message passing near-zero features.
 DEFAULT_EDGE_CUTOFF = RBF_CUTOFF
 
+# van der Waals radius of oxygen, in Angstroms. Sets the clustering and
+# non-maximum-suppression radius when merging predicted water candidates.
+OXYGEN_VDW_RADIUS = 1.52
+
+# Default minimum EDIAm score for a ground-truth water to be kept during
+# training-data quality filtering. Waters scoring below this are dropped as
+# unreliably placed. Shared default for the dataset filters and the CLIs.
+DEFAULT_MIN_EDIA = 0.4
+
 # Edge type tuples: (src_node_type, edge_name, dst_node_type)
 EDGE_PP = ("protein", "pp", "protein")  # protein -> protein
 EDGE_WW = ("water", "ww", "water")  # water -> water
@@ -136,3 +145,6 @@ ELEMENT_VOCAB = [
     "BR",
 ]
 ELEM_IDX = {e: i for i, e in enumerate(ELEMENT_VOCAB)}
+
+# Index of oxygen in ELEMENT_VOCAB, used to build water (oxygen) node features.
+OXYGEN_INDEX = ELEM_IDX["O"]

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -36,6 +36,8 @@ from torch_geometric.data import Batch, HeteroData
 from tqdm import tqdm
 
 from src.constants import (
+    DEFAULT_EDGE_CUTOFF,
+    DEFAULT_MIN_EDIA,
     EDGE_PP,
     ELEM_IDX,
     ELEMENT_VOCAB,
@@ -832,7 +834,7 @@ def filter_waters_by_quality(
     edia_lookup: dict[tuple, float] | None,
     bfactor_lookup: dict[tuple, float] | None,
     max_protein_dist: float = 6.0,
-    min_edia: float = 0.4,
+    min_edia: float = DEFAULT_MIN_EDIA,
     max_bfactor_zscore: float = 1.5,
     cache_key: str | None = None,
 ) -> np.ndarray:
@@ -927,7 +929,7 @@ class ProteinWaterDataset(Dataset):
         processed_dir: str,
         base_pdb_dir: str,
         encoder_type: str = "gvp",
-        cutoff: float = 8.0,
+        cutoff: float = DEFAULT_EDGE_CUTOFF,
         max_neighbors: int = 256,
         include_mates: bool = True,
         include_ligands: bool = True,
@@ -940,7 +942,7 @@ class ProteinWaterDataset(Dataset):
         interface_dist_threshold: float = 4.0,
         min_water_residue_ratio: float = 0.1,
         max_protein_dist: float = 5.0,
-        min_edia: float = 0.4,
+        min_edia: float = DEFAULT_MIN_EDIA,
         max_bfactor_zscore: float = 2.0,
         filter_by_distance: bool = True,
         filter_by_edia: bool = True,

--- a/src/inference_graph.py
+++ b/src/inference_graph.py
@@ -24,7 +24,7 @@ from loguru import logger
 from torch_cluster import radius_graph
 from torch_geometric.data import HeteroData
 
-from src.constants import EDGE_PP, NODE_FEATURE_DIM, NUM_RBF
+from src.constants import DEFAULT_EDGE_CUTOFF, EDGE_PP, NODE_FEATURE_DIM, NUM_RBF
 from src.dataset import (
     _make_undirected,
     _parse_pdb_resi,
@@ -50,7 +50,7 @@ def build_inference_graph(
     processed_dir: str | Path | None = None,
     include_mates: bool = False,
     include_ligands: bool = True,
-    cutoff: float = 8.0,
+    cutoff: float = DEFAULT_EDGE_CUTOFF,
     max_neighbors: int = 256,
     cache_key: str | None = None,
     cache_load_mmap: bool = True,

--- a/src/utils.py
+++ b/src/utils.py
@@ -243,8 +243,8 @@ def compute_edge_features(
     pos: Tensor,
     edge_index: Tensor,
     pos_dst: Tensor | None = None,
-    num_gaussians: int = 16,
-    cutoff: float = 8.0,
+    num_gaussians: int = NUM_RBF,
+    cutoff: float = RBF_CUTOFF,
     clamp_min: float = 1e-5,
 ) -> tuple[Tensor, Tensor]:
     """

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,86 @@
+"""Tests for shared constants consolidated into src.constants (issue #104).
+
+These guard against values drifting back out of ``constants.py`` into
+re-declared literals scattered across the source modules.
+"""
+
+import inspect
+
+import pytest
+
+from src.constants import (
+    DEFAULT_EDGE_CUTOFF,
+    DEFAULT_MIN_EDIA,
+    ELEM_IDX,
+    NUM_RBF,
+    OXYGEN_INDEX,
+    OXYGEN_VDW_RADIUS,
+    RBF_CUTOFF,
+)
+
+
+@pytest.mark.unit
+class TestSharedConstants:
+    def test_oxygen_vdw_radius_value(self):
+        assert OXYGEN_VDW_RADIUS == pytest.approx(1.52)
+
+    def test_default_min_edia_value(self):
+        assert DEFAULT_MIN_EDIA == pytest.approx(0.4)
+
+    def test_oxygen_index_matches_element_vocab(self):
+        # OXYGEN_INDEX must stay in sync with the element vocabulary it derives from.
+        assert OXYGEN_INDEX == ELEM_IDX["O"]
+
+
+@pytest.mark.unit
+class TestDefaultsMatchSharedConstants:
+    """Downstream defaults should *match* the shared constants. These compare each
+    recorded default value against the constant, catching drift where a constant is
+    changed but a call site keeps a stale literal. (They assert value equality, not
+    that the source literally imports the name.)"""
+
+    def test_cluster_waters_vdw_uses_oxygen_vdw_radius(self):
+        from src.confidence import cluster_waters_vdw
+
+        default = inspect.signature(cluster_waters_vdw).parameters["radius"].default
+        assert default == OXYGEN_VDW_RADIUS
+
+    def test_filter_waters_by_quality_uses_default_min_edia(self):
+        from src.dataset import filter_waters_by_quality
+
+        default = (
+            inspect.signature(filter_waters_by_quality).parameters["min_edia"].default
+        )
+        assert default == DEFAULT_MIN_EDIA
+
+    def test_dataset_init_uses_default_min_edia(self):
+        from src.dataset import ProteinWaterDataset
+
+        default = (
+            inspect.signature(ProteinWaterDataset.__init__)
+            .parameters["min_edia"]
+            .default
+        )
+        assert default == DEFAULT_MIN_EDIA
+
+    def test_compute_edge_features_uses_rbf_constants(self):
+        from src.utils import compute_edge_features
+
+        params = inspect.signature(compute_edge_features).parameters
+        assert params["cutoff"].default == RBF_CUTOFF
+        assert params["num_gaussians"].default == NUM_RBF
+
+    def test_edge_cutoff_defaults_use_default_edge_cutoff(self):
+        # Every graph-construction entry point should default its edge cutoff to
+        # the shared DEFAULT_EDGE_CUTOFF rather than a bare 8.0.
+        from src.confidence import ConfidenceGVP
+        from src.dataset import ProteinWaterDataset
+        from src.inference_graph import build_inference_graph
+
+        for func in (
+            ConfidenceGVP.__init__,
+            ProteinWaterDataset.__init__,
+            build_inference_graph,
+        ):
+            default = inspect.signature(func).parameters["cutoff"].default
+            assert default == DEFAULT_EDGE_CUTOFF, f"{func.__qualname__} cutoff default"


### PR DESCRIPTION
Nice library! Wanted to start with sth. small to get familiar, so I picked up #104 

Moved the constants that were defined locally or hardcoded in a few places into `constants.py` and import them from there. No behavioiur change, same values everywhere with a small test so they don't drift back. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized default settings for graph connectivity, water-quality filtering, and edge-feature calculations across training, inference, and dataset workflows.
  * Centralized oxygen-related values and quality thresholds to ensure consistent results across processing stages.
  * Existing default behavior is preserved while reducing inconsistencies between workflows.

* **Tests**
  * Added coverage to verify shared defaults and their use throughout relevant workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->