### PR TITLE
Add correctness tests for Euler/RK4 integration

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -868,7 +868,7 @@ class TestFlowMatcher:
         same (small) step count -- i.e. RK4's higher order converges faster."""
         flow_matcher.model = _LinearDecayVelocity(k=1.0).to(device)
 
-        def run(method: str, num_steps: int, seed: int):
+        def run(method: str, num_steps: int, seed: int, trajectory: bool = False):
             # Same seed => same prior noise (the integration's only randomness),
             # so the runs are compared from identical initial positions.
             gen = torch.Generator(device=device).manual_seed(seed)
@@ -877,22 +877,23 @@ class TestFlowMatcher:
                 simple_hetero_data,
                 num_steps=num_steps,
                 device=str(device),
-                return_trajectory=True,
+                return_trajectory=trajectory,
                 generator=gen,
             )[0]
 
         seed = 1234
+        # The prior is drawn before the first step, so a 2-step run exposes the
+        # same initial noise the long runs start from, without keeping 2000
+        # frames alive (each one copies to CPU and converts to NumPy).
+        x0_euler = run("euler", num_steps=2, seed=seed, trajectory=True)["trajectory"][
+            0
+        ]
+        x0_rk4 = run("rk4", num_steps=2, seed=seed, trajectory=True)["trajectory"][0]
+        np.testing.assert_allclose(x0_rk4, x0_euler, atol=1e-5)
+
         euler_fine = run("euler", num_steps=2000, seed=seed)
         rk4_coarse = run("rk4", num_steps=21, seed=seed)
         euler_coarse = run("euler", num_steps=21, seed=seed)
-
-        # Identical initial noise across the three runs (guards the comparison).
-        np.testing.assert_allclose(
-            rk4_coarse["trajectory"][0], euler_fine["trajectory"][0], atol=1e-5
-        )
-        np.testing.assert_allclose(
-            euler_coarse["trajectory"][0], euler_fine["trajectory"][0], atol=1e-5
-        )
 
         reference = euler_fine["water_pred"]
         # Coarse RK4 converges to the fine-step Euler solution.

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -3,6 +3,7 @@
 All test cases created with assistance from Claude Code and refined.
 """
 
+import copy
 from unittest.mock import Mock
 
 import numpy as np
@@ -625,6 +626,73 @@ class TestFlowWaterGVP:
 # ============== Tests for FlowMatcher ==============
 
 
+class _ConstantVelocity(torch.nn.Module):
+    """Velocity field v(x, t) = c, independent of state and time.
+
+    Integrating dx/dt = c from t=0 to t=1 gives x(1) = x(0) + c exactly, so it
+    lets the integrators be checked against a closed-form trajectory.
+    """
+
+    def __init__(self, velocity):
+        super().__init__()
+        self.velocity = torch.as_tensor(velocity, dtype=torch.float32)
+
+    def forward(self, g, t):
+        pos = g["water"].pos
+        return self.velocity.to(pos).view(1, 3).expand(pos.shape[0], 3)
+
+
+class _LinearDecayVelocity(torch.nn.Module):
+    """Velocity field v(x, t) = -k x. Solves to x(1) = x(0) * exp(-k).
+
+    A genuine ODE where the step count matters, used to check that RK4 with few
+    steps converges to Euler with many.
+    """
+
+    def __init__(self, k):
+        super().__init__()
+        self.k = float(k)
+
+    def forward(self, g, t):
+        return -self.k * g["water"].pos
+
+
+class _TimeRampVelocity(torch.nn.Module):
+    """Velocity field v(x, t) = a * t: independent of state, linear in time.
+
+    The fields above ignore t, so nothing about them notices a stage evaluated at
+    the wrong time. Here the quadrature is known in closed form for both methods
+    (RK4's Simpson weights are exact on a linear integrand, Euler's left
+    rectangles fall short by a known amount), which pins the stage times down.
+    """
+
+    def __init__(self, a):
+        super().__init__()
+        self.a = torch.as_tensor(a, dtype=torch.float32)
+
+    def forward(self, g, t):
+        pos = g["water"].pos
+        t_w = t.to(pos)[g["water"].batch].view(-1, 1)
+        return self.a.to(pos).view(1, 3) * t_w
+
+
+class _PerGraphVelocity(torch.nn.Module):
+    """Velocity field v = (graph_index + 1) * c, constant in state and time.
+
+    Each graph in a batch moves by a different amount, so results split back to
+    the wrong graph -- or waters mixed across graphs -- cannot pass.
+    """
+
+    def __init__(self, c):
+        super().__init__()
+        self.c = torch.as_tensor(c, dtype=torch.float32)
+
+    def forward(self, g, t):
+        pos = g["water"].pos
+        scale = (g["water"].batch.to(pos) + 1.0).view(-1, 1)
+        return self.c.to(pos).view(1, 3) * scale
+
+
 @pytest.mark.unit
 class TestFlowMatcher:
     @pytest.fixture
@@ -751,6 +819,160 @@ class TestFlowMatcher:
 
         n_water = simple_hetero_data["water"].num_nodes
         assert water_pred.shape == (n_water, 3)
+
+    # ---- Integration correctness (issue #58) ----
+    # The tests above check output shapes/keys; these check the numerical
+    # behavior of the Euler and RK4 steppers against closed-form solutions,
+    # driven by analytic velocity fields (mocked model) rather than the encoder.
+
+    @pytest.mark.parametrize("method", ["euler", "rk4"])
+    def test_constant_field_gives_linear_trajectory(
+        self, flow_matcher, simple_hetero_data, device, method
+    ):
+        """A constant velocity field c must produce a straight-line trajectory
+        with total displacement exactly c, for both Euler and RK4 and regardless
+        of step count (dx/dt = c over t in [0, 1] => x(1) = x(0) + c)."""
+        c = torch.tensor([1.0, -2.0, 0.5], device=device)
+        flow_matcher.model = _ConstantVelocity(c).to(device)
+        integrate = getattr(flow_matcher, f"{method}_integrate")
+
+        num_steps = 11
+        result = integrate(
+            simple_hetero_data,
+            num_steps=num_steps,
+            device=str(device),
+            return_trajectory=True,
+        )[0]
+        trajectory = result["trajectory"]
+        assert len(trajectory) == num_steps
+
+        x0 = trajectory[0]
+        c_np = c.cpu().numpy()
+
+        # Net displacement equals the (constant) velocity, independent of steps.
+        np.testing.assert_allclose(
+            result["water_pred"] - x0,
+            np.broadcast_to(c_np, x0.shape),
+            atol=1e-3,
+        )
+        # Every intermediate frame lies on the line x0 + (k / (num_steps-1)) * c.
+        for k, frame in enumerate(trajectory):
+            expected = x0 + (k / (num_steps - 1)) * c_np
+            np.testing.assert_allclose(frame, expected, atol=1e-3)
+
+    def test_rk4_matches_euler_with_more_steps(
+        self, flow_matcher, simple_hetero_data, device
+    ):
+        """On the decay field dx/dt = -x, coarse RK4 should reach the same
+        solution as fine-step Euler, and be far more accurate than Euler at the
+        same (small) step count -- i.e. RK4's higher order converges faster."""
+        flow_matcher.model = _LinearDecayVelocity(k=1.0).to(device)
+
+        def run(method: str, num_steps: int, seed: int):
+            # Same seed => same prior noise (the integration's only randomness),
+            # so the runs are compared from identical initial positions.
+            gen = torch.Generator(device=device).manual_seed(seed)
+            integrate = getattr(flow_matcher, f"{method}_integrate")
+            return integrate(
+                simple_hetero_data,
+                num_steps=num_steps,
+                device=str(device),
+                return_trajectory=True,
+                generator=gen,
+            )[0]
+
+        seed = 1234
+        euler_fine = run("euler", num_steps=2000, seed=seed)
+        rk4_coarse = run("rk4", num_steps=21, seed=seed)
+        euler_coarse = run("euler", num_steps=21, seed=seed)
+
+        # Identical initial noise across the three runs (guards the comparison).
+        np.testing.assert_allclose(
+            rk4_coarse["trajectory"][0], euler_fine["trajectory"][0], atol=1e-5
+        )
+        np.testing.assert_allclose(
+            euler_coarse["trajectory"][0], euler_fine["trajectory"][0], atol=1e-5
+        )
+
+        reference = euler_fine["water_pred"]
+        # Coarse RK4 converges to the fine-step Euler solution.
+        np.testing.assert_allclose(
+            rk4_coarse["water_pred"], reference, rtol=2e-2, atol=2e-2
+        )
+        # RK4 is closer to the reference than Euler at the same step count.
+        rk4_err = np.linalg.norm(rk4_coarse["water_pred"] - reference)
+        euler_err = np.linalg.norm(euler_coarse["water_pred"] - reference)
+        assert rk4_err < euler_err
+
+    def test_time_dependent_field_uses_correct_stage_times(
+        self, flow_matcher, simple_hetero_data, device
+    ):
+        """On v(x, t) = a*t both integrators have a closed-form answer that
+        depends only on the times they evaluate the field at: RK4 integrates a
+        linear integrand exactly, Euler's left rectangles miss by a known
+        deficit. The constant/decay fields above are time-independent, so this
+        is what catches a stage fed the wrong t."""
+        a = torch.tensor([2.0, -1.0, 4.0], device=device)
+        flow_matcher.model = _TimeRampVelocity(a).to(device)
+        a_np = a.cpu().numpy()
+
+        num_steps = 11
+        kwargs = {
+            "num_steps": num_steps,
+            "device": str(device),
+            "return_trajectory": True,
+        }
+        rk4 = flow_matcher.rk4_integrate(simple_hetero_data, **kwargs)[0]
+        euler = flow_matcher.euler_integrate(simple_hetero_data, **kwargs)[0]
+
+        # RK4: integral of a*t over [0, 1] = a/2, exactly.
+        rk4_shift = rk4["water_pred"] - rk4["trajectory"][0]
+        np.testing.assert_allclose(
+            rk4_shift, np.broadcast_to(a_np / 2.0, rk4_shift.shape), atol=1e-4
+        )
+
+        # Euler: dt * sum(t_i) over the num_steps-1 left endpoints, which is
+        # a * (num_steps - 2) / (2 * (num_steps - 1)).
+        euler_shift = euler["water_pred"] - euler["trajectory"][0]
+        expected = a_np * (num_steps - 2) / (2 * (num_steps - 1))
+        np.testing.assert_allclose(
+            euler_shift, np.broadcast_to(expected, euler_shift.shape), atol=1e-4
+        )
+
+    @pytest.mark.parametrize("method", ["euler", "rk4"])
+    def test_batched_integration_splits_results_per_graph(
+        self, flow_matcher, simple_hetero_data, device, method
+    ):
+        """Inference integrates a list of graphs in one batch, so the per-graph
+        split of the final positions and trajectories has to be right. The two
+        graphs differ in water count and in velocity, so a wrong mask shows up."""
+        g0 = simple_hetero_data
+        g1 = copy.deepcopy(simple_hetero_data)
+        # Second graph: 3 waters instead of 5, so a mis-split changes shapes too.
+        g1["water"].pos = torch.randn(3, 3, device=device)
+        g1["water"].x = torch.randn(3, 16, device=device)
+        g1["water"].batch = torch.zeros(3, dtype=torch.long, device=device)
+
+        c = torch.tensor([1.0, -2.0, 0.5], device=device)
+        flow_matcher.model = _PerGraphVelocity(c).to(device)
+        integrate = getattr(flow_matcher, f"{method}_integrate")
+
+        num_steps = 7
+        results = integrate(
+            [g0, g1], num_steps=num_steps, device=str(device), return_trajectory=True
+        )
+
+        assert len(results) == 2
+        c_np = c.cpu().numpy()
+        for i, (result, n_water) in enumerate(zip(results, (5, 3))):
+            assert result["water_pred"].shape == (n_water, 3)
+            assert len(result["trajectory"]) == num_steps
+            assert all(f.shape == (n_water, 3) for f in result["trajectory"])
+            # Graph i moves by (i + 1) * c over t in [0, 1].
+            shift = result["water_pred"] - result["trajectory"][0]
+            np.testing.assert_allclose(
+                shift, np.broadcast_to((i + 1) * c_np, shift.shape), atol=1e-3
+            )
 
 
 # ============== Tests for water sampling strategies ==============


### PR DESCRIPTION
Another go at #58. `test_euler_integrate` and `test_rk4_integrate` assert shapes and dict keys only, so nothing in the suite notices if either integrator computes the wrong numbers.

The approach is to swap the model for an analytic velocity field. The ODE then has a solution in closed form, and the integrator output can be compared to it directly - this tests the stepper arithmetic, not the network.

**Constant field, `v = c`** (both methods). Integrating
`dx/dt = c` over `t ∈ [0,1]` gives `x(1) = x(0) + c` whatever the step count,
and frame `k` sits on `x0 + k/(N-1) * c`. RK4 is exact here too, since
`(dt/6)(c + 2c + 2c + c) = dt*c`.

**Decay field, `v = -x`** (the convergence check). The solution is
`x(1) = x(0) * e^-1`. Against a 2000-step Euler reference, 21-step RK4 agrees to
`rtol=2e-2`, and its error is strictly smaller than 21-step Euler's - the fourth
order buys accuracy the first order does not.

**Ramp field, `v = a*t`.** Both fields above ignore `t`, so neither notices a
stage evaluated at the wrong time - but the model is time-conditioned and RK4's
midpoint and endpoint times are load-bearing. Here the quadrature is known:
Simpson's weights are exact on a linear integrand, so RK4 lands on `a/2`, while
Euler's left rectangles give exactly `a*(N-2)/(2*(N-1))`.

**Batching.** Two graphs with 5 and 3 waters and a per-graph velocity
`(i+1)*c`, covering the list-of-graphs path in `scripts/inference.py` that every
existing integration test misses.